### PR TITLE
Fix mypy error

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,4 +38,4 @@ repos:
     rev: v0.790
     hooks:
     - id: mypy
-      additional_dependencies: [markdown-it-py]
+      additional_dependencies: [markdown-it-py>=0.6.0]

--- a/mdit_py_plugins/deflist/index.py
+++ b/mdit_py_plugins/deflist/index.py
@@ -22,7 +22,7 @@ def deflist_plugin(md: MarkdownIt):
         ~ Definition 2b
 
     """
-    isSpace = md.utils.isSpace
+    isSpace = md.utils.isSpace  # type: ignore
 
     def skipMarker(state: StateBlock, line: int):
         """Search `[:~][\n ]`, returns next pos after marker on success or -1 on fail."""


### PR DESCRIPTION
Fix a mypy error that occurs after `markdown-it-py` v0.6.0 was released (because now this project can access `markdown-it-py` type annotations).