### PR TITLE
👌 IMPROVE: Remove direct use of `Token.attrs`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,15 +24,15 @@ repos:
     hooks:
     - id: check-manifest
 
-  - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.8.4
-    hooks:
-    - id: flake8
-
   - repo: https://github.com/psf/black
     rev: 20.8b1
     hooks:
     - id: black
+
+  - repo: https://gitlab.com/pycqa/flake8
+    rev: 3.8.4
+    hooks:
+    - id: flake8
 
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v0.790

--- a/mdit_py_plugins/anchors/index.py
+++ b/mdit_py_plugins/anchors/index.py
@@ -85,13 +85,15 @@ def _make_anchors_func(
             token.attrSet("id", slug)
 
             if permalink:
+                link_open = Token(
+                    "link_open",
+                    "a",
+                    1,
+                )
+                link_open.attrSet("class", "header-anchor")
+                link_open.attrSet("href", f"#{slug}")
                 link_tokens = [
-                    Token(
-                        "link_open",
-                        "a",
-                        1,
-                        attrs=[["class", "header-anchor"], ["href", f"#{slug}"]],
-                    ),
+                    link_open,
                     Token("html_block", "", 0, content=permalinkSymbol),
                     Token("link_close", "a", -1),
                 ]

--- a/mdit_py_plugins/tasklists/__init__.py
+++ b/mdit_py_plugins/tasklists/__init__.py
@@ -54,24 +54,15 @@ def tasklists_plugin(
 
             if is_todo_item(tokens, i):
                 todoify(tokens[i], tokens[i].__class__)
-                attr_set(
-                    tokens[i - 2],
+                tokens[i - 2].attrSet(
                     "class",
                     "task-list-item" + (" enabled" if not disable_checkboxes else ""),
                 )
-                attr_set(
-                    tokens[parent_token(tokens, i - 2)], "class", "contains-task-list"
+                tokens[parent_token(tokens, i - 2)].attrSet(
+                    "class", "contains-task-list"
                 )
 
     md.core.ruler.after("inline", "github-tasklists", fcn)
-
-    def attr_set(token, name, value):
-        index = token.attrIndex(name)
-        attr = [name, value]
-        if index < 0:
-            token.attrPush(attr)
-        else:
-            token.attrs[index] = attr
 
     def parent_token(tokens, index):
         target_level = tokens[index].level - 1

--- a/tests/test_myst_block.py
+++ b/tests/test_myst_block.py
@@ -22,61 +22,58 @@ def test_all(line, title, input, expected):
 def test_block_token():
     md = MarkdownIt("commonmark").use(myst_block_plugin)
     tokens = md.parse("+++")
-    assert tokens == [
-        Token(
-            type="myst_block_break",
-            tag="hr",
-            nesting=0,
-            attrs=[["class", "myst-block"]],
-            map=[0, 1],
-            level=0,
-            children=None,
-            content="",
-            markup="+++",
-            info="",
-            meta={},
-            block=True,
-            hidden=False,
-        )
-    ]
+    expected_token = Token(
+        type="myst_block_break",
+        tag="hr",
+        nesting=0,
+        map=[0, 1],
+        level=0,
+        children=None,
+        content="",
+        markup="+++",
+        info="",
+        meta={},
+        block=True,
+        hidden=False,
+    )
+    expected_token.attrSet("class", "myst-block")
+    assert tokens == [expected_token]
 
     tokens = md.parse("\n+ + + abc")
-    assert tokens == [
-        Token(
-            type="myst_block_break",
-            tag="hr",
-            nesting=0,
-            attrs=[["class", "myst-block"]],
-            map=[1, 2],
-            level=0,
-            children=None,
-            content="abc",
-            markup="+++",
-            info="",
-            meta={},
-            block=True,
-            hidden=False,
-        )
-    ]
+    expected_token = Token(
+        type="myst_block_break",
+        tag="hr",
+        nesting=0,
+        map=[1, 2],
+        level=0,
+        children=None,
+        content="abc",
+        markup="+++",
+        info="",
+        meta={},
+        block=True,
+        hidden=False,
+    )
+    expected_token.attrSet("class", "myst-block")
+    assert tokens == [expected_token]
 
 
 def test_comment_token():
     md = MarkdownIt("commonmark").use(myst_block_plugin)
     tokens = md.parse("\n\n% abc")
-    assert tokens == [
-        Token(
-            type="myst_line_comment",
-            tag="",
-            nesting=0,
-            attrs=[["class", "myst-line-comment"]],
-            map=[2, 3],
-            level=0,
-            children=None,
-            content="abc",
-            markup="%",
-            info="",
-            meta={},
-            block=True,
-            hidden=False,
-        )
-    ]
+    expected_token = Token(
+        type="myst_line_comment",
+        tag="",
+        nesting=0,
+        map=[2, 3],
+        level=0,
+        children=None,
+        content="abc",
+        markup="%",
+        info="",
+        meta={},
+        block=True,
+        hidden=False,
+    )
+    expected_token.attrSet("class", "myst-line-comment")
+    assert tokens == [expected_token]


### PR DESCRIPTION
This commit ensures `Token.attrSet` is used instead,
in anticipation of the upstream format of `Token.attrs`.