### PR TITLE
👌 IMPROVE: Parse multiline MyST comments

### DIFF
--- a/mdit_py_plugins/myst_blocks/index.py
+++ b/mdit_py_plugins/myst_blocks/index.py
@@ -41,8 +41,7 @@ def line_comment(state: StateBlock, startLine: int, endLine: int, silent: bool):
     if state.sCount[startLine] - state.blkIndent >= 4:
         return False
 
-    percent_code = ord("%")
-    if state.srcCharCode[pos] != percent_code:
+    if state.src[pos] != "%":
         return False
 
     if silent:
@@ -60,7 +59,7 @@ def line_comment(state: StateBlock, startLine: int, endLine: int, silent: bool):
         pos = state.bMarks[nextLine] + state.tShift[nextLine]
         maximum = state.eMarks[nextLine]
 
-        if state.srcCharCode[pos] != percent_code:
+        if state.src[pos] != "%":
             break
         token.content += "\n" + state.src[pos + 1 : maximum].rstrip()
 

--- a/mdit_py_plugins/myst_blocks/index.py
+++ b/mdit_py_plugins/myst_blocks/index.py
@@ -1,4 +1,5 @@
 import re
+import itertools
 
 from markdown_it import MarkdownIt
 from markdown_it.rules_block import StateBlock
@@ -40,23 +41,31 @@ def line_comment(state: StateBlock, startLine: int, endLine: int, silent: bool):
     if state.sCount[startLine] - state.blkIndent >= 4:
         return False
 
-    marker = state.srcCharCode[pos]
-    pos += 1
-
-    # Check block marker /* % */
-    if marker != 0x25:
+    percent_code = ord("%")
+    if state.srcCharCode[pos] != percent_code:
         return False
 
     if silent:
         return True
 
-    state.line = startLine + 1
-
     token = state.push("myst_line_comment", "", 0)
     token.attrSet("class", "myst-line-comment")
-    token.content = state.src[pos:maximum].rstrip()
-    token.map = [startLine, state.line]
-    token.markup = chr(marker)
+    token.content = state.src[pos + 1 : maximum].rstrip()
+    token.markup = "%"
+
+    # search end of block while appending lines to `token.content`
+    for nextLine in itertools.count(startLine + 1):
+        if nextLine >= endLine:
+            break
+        pos = state.bMarks[nextLine] + state.tShift[nextLine]
+        maximum = state.eMarks[nextLine]
+
+        if state.srcCharCode[pos] != percent_code:
+            break
+        token.content += "\n" + state.src[pos + 1 : maximum].rstrip()
+
+    state.line = nextLine
+    token.map = [startLine, nextLine]
 
     return True
 
@@ -140,5 +149,6 @@ def render_myst_target(self, tokens, idx, options, env):
 
 
 def render_myst_line_comment(self, tokens, idx, options, env):
-    content = tokens[idx].content.lstrip()
-    return f"<!--- {escapeHtml(content)} --->"
+    # Strip leading whitespace from all lines
+    content = "\n".join(line.lstrip() for line in tokens[idx].content.split("\n"))
+    return f"<!-- {escapeHtml(content)} -->"

--- a/mdit_py_plugins/myst_blocks/index.py
+++ b/mdit_py_plugins/myst_blocks/index.py
@@ -1,5 +1,5 @@
-import re
 import itertools
+import re
 
 from markdown_it import MarkdownIt
 from markdown_it.common.utils import escapeHtml, isSpace

--- a/tests/fixtures/myst_block.md
+++ b/tests/fixtures/myst_block.md
@@ -73,7 +73,7 @@ Comment:
 .
 % abc
 .
-<!--- abc --->
+<!-- abc -->
 .
 
 Comment terminates other blocks:
@@ -86,11 +86,38 @@ a
 % abc
 .
 <p>a</p>
-<!--- abc ---><ul>
+<!-- abc --><ul>
 <li>b</li>
 </ul>
-<!--- abc ---><blockquote>
+<!-- abc --><blockquote>
 <p>c</p>
 </blockquote>
-<!--- abc --->
+<!-- abc -->
+.
+
+Multiline comment:
+.
+a
+% abc
+%   def
+- b
+%  abc
+%def
+> c
+%abc
+%
+%def
+.
+<p>a</p>
+<!-- abc
+def --><ul>
+<li>b</li>
+</ul>
+<!-- abc
+def --><blockquote>
+<p>c</p>
+</blockquote>
+<!-- abc
+
+def -->
 .

--- a/tests/test_myst_block.py
+++ b/tests/test_myst_block.py
@@ -60,15 +60,15 @@ def test_block_token():
 
 def test_comment_token():
     md = MarkdownIt("commonmark").use(myst_block_plugin)
-    tokens = md.parse("\n\n% abc")
+    tokens = md.parse("\n\n% abc \n%def")
     expected_token = Token(
         type="myst_line_comment",
         tag="",
         nesting=0,
-        map=[2, 3],
+        map=[2, 4],
         level=0,
         children=None,
-        content=" abc",
+        content=" abc\ndef",
         markup="%",
         info="",
         meta={},


### PR DESCRIPTION
Closes https://github.com/executablebooks/MyST-Parser/issues/349

Also changes HTML comment tags from `<!--- comment --->` to `<!-- comment -->`. If there was a good reason for using three hyphens, then sorry, pls let me know, and I'll revert that change.