### PR TITLE
⬆️ UPDATE: markdown-it-py~=1.0

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,0 @@
-[flake8]
-max-line-length = 100
-ignore = E203,W503

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -61,10 +61,10 @@ jobs:
     steps:
     - name: Checkout source
       uses: actions/checkout@v2
-    - name: Set up Python 3.7
+    - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: 3.7
+        python-version: 3.8
     - name: Build package
       run: |
         pip install wheel

--- a/.mypy.ini
+++ b/.mypy.ini
@@ -1,5 +1,0 @@
-[mypy]
-warn_unused_ignores = True
-warn_redundant_casts = True
-no_implicit_optional = True
-strict_equality = True

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,9 +20,18 @@ repos:
     - id: trailing-whitespace
 
   - repo: https://github.com/mgedmin/check-manifest
-    rev: "0.44"
+    rev: "0.46"
     hooks:
     - id: check-manifest
+      args: [--no-build-isolation]
+      additional_dependencies: [setuptools>=46.4.0]
+
+  # this is not used for now,
+  # since it converts mdit-py-plugins to mdit_py_plugins and removes comments
+  # - repo: https://github.com/asottile/setup-cfg-fmt
+  #   rev: v1.17.0
+  #   hooks:
+  #   - id: setup-cfg-fmt
 
   - repo: https://github.com/psf/black
     rev: 20.8b1
@@ -30,12 +39,13 @@ repos:
     - id: black
 
   - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.8.4
+    rev: 3.9.1
     hooks:
     - id: flake8
+      additional_dependencies: [flake8-bugbear==21.3.1]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.790
+    rev: v0.812
     hooks:
     - id: mypy
-      additional_dependencies: [markdown-it-py>=0.6.0]
+      additional_dependencies: [markdown-it-py~=1.0]

--- a/mdit_py_plugins/front_matter/index.py
+++ b/mdit_py_plugins/front_matter/index.py
@@ -48,10 +48,8 @@ def make_front_matter_rule():
         # Check out the rest of the marker string
         # while pos <= 3
         pos = start + 1
-        start_content = 0
         while pos <= maximum and pos < src_len:
             if marker_str[(pos - start) % marker_len] != state.src[pos]:
-                start_content = pos + 1
                 break
             pos += 1
 
@@ -129,7 +127,6 @@ def make_front_matter_rule():
             state.bMarks[startLine + 1] : state.eMarks[nextLine - 1]
         ]
         token.block = True
-        token.meta = state.src[start_content : start - 1]
 
         state.parentType = old_parent
         state.lineMax = old_line_max

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=46.4.0", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,60 @@
+[metadata]
+name = mdit-py-plugins
+version = attr: mdit_py_plugins.__version__
+description = Collection of plugins for markdown-it-py
+long_description = file: README.md
+long_description_content_type = text/markdown
+url = https://github.com/executablebooks/mdit-py-plugins
+author = Chris Sewell
+author_email = chrisj_sewell@hotmail.com
+license = MIT
+license_file = LICENSE
+classifiers =
+    Development Status :: 2 - Beta
+    Intended Audience :: Developers
+    License :: OSI Approved :: MIT License
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: Implementation :: CPython
+    Programming Language :: Python :: Implementation :: PyPy
+    Topic :: Software Development :: Libraries :: Python Modules
+    Topic :: Text Processing :: Markup
+keywords = markdown, lexer, parser, development
+project_urls =
+    Documentation=https://markdown-it-py.readthedocs.io
+
+[options]
+packages = find:
+install_requires =
+    markdown-it-py~=1.0
+python_requires = ~=3.6
+include_package_data = True
+zip_safe = True
+
+[options.packages.find]
+exclude =
+    test*
+    benchmarking
+
+[options.extras_require]
+code_style =
+    pre-commit==2.6
+testing =
+    coverage
+    pytest>=3.6,<4
+    pytest-cov
+    pytest-regressions
+
+[mypy]
+show_error_codes = True
+warn_unused_ignores = True
+warn_redundant_casts = True
+no_implicit_optional = True
+strict_equality = True
+
+[flake8]
+max-line-length = 100
+extend-ignore = E203

--- a/setup.py
+++ b/setup.py
@@ -1,54 +1,6 @@
-# from importlib import import_module
-from os import path
-import re
-from setuptools import find_packages, setup
+# This file is needed for editable installs (`pip install -e .`).
+# Can be removed once the following is resolved
+# https://github.com/pypa/packaging-problems/issues/256
+from setuptools import setup
 
-
-def get_version():
-    text = open(
-        path.join(path.dirname(__file__), "mdit_py_plugins", "__init__.py")
-    ).read()
-    match = re.compile(r"^__version__\s*\=\s*[\"\']([^\s\'\"]+)", re.M).search(text)
-    return match.group(1)
-
-
-setup(
-    name="mdit-py-plugins",
-    version=get_version(),
-    description="Collection of plugins for markdown-it-py",
-    long_description=open("README.md").read(),
-    long_description_content_type="text/markdown",
-    url="https://github.com/executablebooks/mdit-py-plugins",
-    author="Chris Sewell",
-    author_email="chrisj_sewell@hotmail.com",
-    license="MIT",
-    packages=find_packages(exclude=["test*", "benchmarking"]),
-    include_package_data=True,
-    classifiers=[
-        "Development Status :: 3 - Alpha",
-        "Intended Audience :: Developers",
-        "License :: OSI Approved :: MIT License",
-        "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
-        "Programming Language :: Python :: Implementation :: CPython",
-        "Programming Language :: Python :: Implementation :: PyPy",
-        "Topic :: Software Development :: Libraries :: Python Modules",
-        "Topic :: Text Processing :: Markup",
-    ],
-    keywords="markdown lexer parser development",
-    python_requires="~=3.6",
-    install_requires=["markdown-it-py>=0.5.8,<2.0.0"],
-    extras_require={
-        "code_style": ["pre-commit==2.6"],
-        "testing": [
-            "coverage",
-            "pytest>=3.6,<4",
-            "pytest-cov",
-            "pytest-regressions",
-        ],
-    },
-    zip_safe=True,
-)
+setup()

--- a/tests/fixtures/footnote.md
+++ b/tests/fixtures/footnote.md
@@ -298,3 +298,31 @@ hij</p>
 </ol>
 </section>
 .
+
+Empty lines after blockquote+footnote (markdown-it-py#133)
+.
+> b [^1]
+
+Some text
+
+> c
+
+[^1]: d
+
+
+.
+<blockquote>
+<p>b <sup class="footnote-ref"><a href="#fn1" id="fnref1">[1]</a></sup></p>
+</blockquote>
+<p>Some text</p>
+<blockquote>
+<p>c</p>
+</blockquote>
+<hr class="footnotes-sep">
+<section class="footnotes">
+<ol class="footnotes-list">
+<li id="fn1" class="footnote-item"><p>d <a href="#fnref1" class="footnote-backref">↩︎</a></p>
+</li>
+</ol>
+</section>
+.

--- a/tests/test_front_matter.py
+++ b/tests/test_front_matter.py
@@ -35,7 +35,7 @@ def test_token():
             content="a: 1",
             markup="---",
             info="",
-            meta="a: 1",
+            meta={},
             block=True,
             hidden=True,
         )


### PR DESCRIPTION
- Update setup to static configuration
- Add yproject.toml
- Update pre-commit  hooks
- Add footnote test for recent fix
- Fix mypy fail for front_matter `Token.meta`
  (we parse `Token.content`, so this is not necessary)
