### PR TITLE
👌 IMPROVE: Allow inline double-dollar (dollarmath_plugin)

### DIFF
--- a/mdit_py_plugins/dollarmath/index.py
+++ b/mdit_py_plugins/dollarmath/index.py
@@ -42,23 +42,28 @@ def dollarmath_plugin(
     md.add_render_rule("math_block_eqno", render_math_block_eqno)
 
 
-def render_math_inline(self, tokens, idx, options, env):
+# TODO the current render rules are really just for testing
+# would be good to allow "proper" math rendering, e.g. https://github.com/roniemartinez/latex2mathml
+
+
+def render_math_inline(self, tokens, idx, options, env) -> str:
     return "<{0}>{1}</{0}>".format(
         "eqn" if tokens[idx].markup == "$$" else "eq", tokens[idx].content
     )
 
 
-def render_math_block(self, tokens, idx, options, env):
+def render_math_block(self, tokens, idx, options, env) -> str:
     return "<section>\n<eqn>{0}</eqn>\n</section>\n".format(tokens[idx].content)
 
 
-def render_math_block_eqno(self, tokens, idx, options, env):
+def render_math_block_eqno(self, tokens, idx, options, env) -> str:
     return '<section>\n<eqn>{0}</eqn>\n<span class="eqno">({1})</span>\n</section>\n'.format(
         tokens[idx].content, tokens[idx].info
     )
 
 
-def is_escaped(state: StateInline, back_pos: int, mod: int = 0):
+def is_escaped(state: StateInline, back_pos: int, mod: int = 0) -> bool:
+    """Test if dollar is escaped."""
     # count how many \ are before the current position
     backslashes = 0
     while back_pos >= 0:
@@ -69,7 +74,7 @@ def is_escaped(state: StateInline, back_pos: int, mod: int = 0):
             break
 
     if not backslashes:
-        return
+        return False
 
     # if an odd number of \ then ignore
     if (backslashes % 2) != mod:
@@ -209,10 +214,14 @@ def math_inline_dollar(
 DOLLAR_EQNO_REV = re.compile(r"^\s*\)([^)$\r\n]+?)\(\s*\${2}")
 
 
-def math_block_dollar(allow_labels=True):
+def math_block_dollar(
+    allow_labels: bool = True,
+) -> Callable[[StateBlock, int, int, bool], bool]:
+    """Generate block dollar rule."""
+
     def _math_block_dollar(
         state: StateBlock, startLine: int, endLine: int, silent: bool
-    ):
+    ) -> bool:
 
         # TODO internal backslash escaping
 

--- a/tests/fixtures/dollar_math.md
+++ b/tests/fixtures/dollar_math.md
@@ -1,3 +1,17 @@
+single dollar
+.
+$
+.
+<p>$</p>
+.
+
+double-dollar
+.
+$$
+.
+<p>$$</p>
+.
+
 single character inline equation. (valid=True)
 .
 $a$

--- a/tests/fixtures/dollar_math.md
+++ b/tests/fixtures/dollar_math.md
@@ -497,3 +497,32 @@ $p_2 = \\$a
 .
 <p><eq>p_2 = \\</eq>a</p>
 .
+
+Inline double-dollar:
+.
+a $$a=1$$ (1) b
+.
+<p>a <eqn>a=1</eqn> (1) b</p>
+.
+
+Inline double-dollar, escaped:
+.
+a \$$a=1$$ b
+.
+<p>a $<eq>a=1</eq>$ b</p>
+.
+
+Inline mixed single/double dollars:
+.
+Hence, for $\alpha \in (0, 1)$,
+$$
+  \mathbb P (\alpha \bar{X} \ge \mu) \le \alpha;
+$$
+i.e., $[\alpha \bar{X}, \infty)$ is a lower 1-sided $1-\alpha$ confidence bound for $\mu$.
+.
+<p>Hence, for <eq>\alpha \in (0, 1)</eq>,
+<eqn>
+  \mathbb P (\alpha \bar{X} \ge \mu) \le \alpha;
+</eqn>
+i.e., <eq>[\alpha \bar{X}, \infty)</eq> is a lower 1-sided <eq>1-\alpha</eq> confidence bound for <eq>\mu</eq>.</p>
+.

--- a/tests/fixtures/dollar_math.md
+++ b/tests/fixtures/dollar_math.md
@@ -498,7 +498,21 @@ $p_2 = \\$a
 <p><eq>p_2 = \\</eq>a</p>
 .
 
-Inline double-dollar:
+Inline double-dollar start:
+.
+$$a=1$$ b
+.
+<p><eqn>a=1</eqn> b</p>
+.
+
+Inline double-dollar end:
+.
+a $$a=1$$
+.
+<p>a <eqn>a=1</eqn></p>
+.
+
+Inline double-dollar enclosed:
 .
 a $$a=1$$ (1) b
 .

--- a/tests/test_dollarmath.py
+++ b/tests/test_dollarmath.py
@@ -88,9 +88,9 @@ def test_plugin_parse(data_regression):
 )
 def test_dollarmath_fixturess(line, title, input, expected):
     md = MarkdownIt("commonmark").use(
-        dollarmath_plugin, allow_space=False, allow_digits=False
+        dollarmath_plugin, allow_space=False, allow_digits=False, double_inline=True
     )
-    md.options["xhtmlOut"] = False
+    md.options.xhtmlOut = False
     text = md.render(input)
     print(text)
     assert text.rstrip() == expected.rstrip()


### PR DESCRIPTION
Switched on using the `double_inline` variable
(currently `False` by default)