### PR TITLE
📚 DOCS: Add documentation!

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,12 @@
+version: 2
+
+python:
+  version: 3
+  install:
+  - method: pip
+    path: .
+    extra_requirements: [rtd]
+
+sphinx:
+  builder: html
+  fail_on_warning: true

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,5 @@
+exclude docs
+recursive-exclude docs *
 exclude tests
 recursive-exclude tests *
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,29 @@
+project = "mdit-py-plugins"
+copyright = "2020, Executable Book Project"
+author = "Executable Book Project"
+
+master_doc = "index"
+
+extensions = [
+    "sphinx.ext.autodoc",
+    "sphinx.ext.viewcode",
+    "sphinx.ext.intersphinx",
+    "myst_parser",
+]
+
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
+
+intersphinx_mapping = {
+    "python": ("https://docs.python.org/3.8", None),
+    "markdown_it": ("https://markdown-it-py.readthedocs.io/en/latest", None),
+}
+
+html_title = "mdit-py-plugins"
+html_theme = "sphinx_book_theme"
+html_theme_options = {
+    "single_page": True,
+    "use_edit_page_button": True,
+    "repository_url": "https://github.com/executablebooks/mdit-py-plugins",
+    "repository_branch": "master",
+    "path_to_docs": "docs",
+}

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,117 @@
+# `markdown-it-py` plugin extensions
+
+## Built-in
+
+The following plugins are embedded within the core package:
+
+- [tables](https://help.github.com/articles/organizing-information-with-tables/) (GFM)
+- [strikethrough](https://help.github.com/articles/basic-writing-and-formatting-syntax/#styling-text) (GFM)
+
+These can be enabled individually:
+
+```python
+from markdown_it import MarkdownIt
+md = MarkdownIt("commonmark").enable('table')
+```
+
+or as part of a configuration:
+
+```python
+from markdown_it import MarkdownIt
+md = MarkdownIt("gfm-like")
+```
+
+```{seealso}
+See [](markdown_it:using)
+```
+
+## `mdit_py_plugins` package
+
+The [`mdit_py_plugins`](https://github.com/executablebooks/mdit-py-plugins), contains a number of common plugins.
+They can be chained and loaded *via*:
+
+```python
+from markdown_it import MarkdownIt
+from mdit_py_plugins import plugin1, plugin2
+md = MarkdownIt().use(plugin1, keyword=value).use(plugin2, keyword=value)
+html_string = md.render("some *Markdown*")
+```
+
+## Front-Matter
+
+```{eval-rst}
+.. autofunction:: mdit_py_plugins.front_matter.front_matter_plugin
+```
+
+## Footnotes
+
+```{eval-rst}
+.. autofunction:: mdit_py_plugins.footnote.footnote_plugin
+```
+
+## Definition Lists
+
+```{eval-rst}
+.. autofunction:: mdit_py_plugins.deflist.deflist_plugin
+```
+
+## Task lists
+
+```{eval-rst}
+.. autofunction:: mdit_py_plugins.tasklists.tasklists_plugin
+```
+
+## Heading Anchors
+
+```{eval-rst}
+.. autofunction:: mdit_py_plugins.anchors.anchors_plugin
+```
+
+## Word Count
+
+```{eval-rst}
+.. autofunction:: mdit_py_plugins.wordcount.wordcount_plugin
+```
+
+## Containers
+
+```{eval-rst}
+.. autofunction:: mdit_py_plugins.container.container_plugin
+```
+
+## Math
+
+```{eval-rst}
+.. autofunction:: mdit_py_plugins.texmath.texmath_plugin
+```
+
+```{eval-rst}
+.. autofunction:: mdit_py_plugins.dollarmath.dollarmath_plugin
+```
+
+```{eval-rst}
+.. autofunction:: mdit_py_plugins.amsmath.amsmath_plugin
+```
+
+## MyST plugins
+
+`myst_blocks` and `myst_role` plugins are also available, for utilisation by the [MyST renderer](https://myst-parser.readthedocs.io/en/latest/using/syntax.html)
+
+```{eval-rst}
+.. autofunction:: mdit_py_plugins.myst_role.myst_role_plugin
+.. autofunction:: mdit_py_plugins.myst_blocks.myst_block_plugin
+```
+
+## Write your own
+
+Use the `mdit_py_plugins` as a guide to write your own, following the [markdown-it design principles](markdown_it:architecture).
+
+There are many other plugins which could easily be ported from the JS versions (and hopefully will be):
+
+- [subscript](https://github.com/markdown-it/markdown-it-sub)
+- [superscript](https://github.com/markdown-it/markdown-it-sup)
+- [abbreviation](https://github.com/markdown-it/markdown-it-abbr)
+- [emoji](https://github.com/markdown-it/markdown-it-emoji)
+- [insert](https://github.com/markdown-it/markdown-it-ins)
+- [mark](https://github.com/markdown-it/markdown-it-mark)
+- ... and [others](https://www.npmjs.org/browse/keyword/markdown-it-plugin)

--- a/docs/index.md
+++ b/docs/index.md
@@ -106,7 +106,7 @@ html_string = md.render("some *Markdown*")
 
 Use the `mdit_py_plugins` as a guide to write your own, following the [markdown-it design principles](markdown_it:architecture).
 
-There are many other plugins which could easily be ported from the JS versions (and hopefully will be):
+There are many other plugins which could easily be ported from the JS versions (and hopefully will):
 
 - [subscript](https://github.com/markdown-it/markdown-it-sub)
 - [superscript](https://github.com/markdown-it/markdown-it-sup)

--- a/mdit_py_plugins/myst_blocks/index.py
+++ b/mdit_py_plugins/myst_blocks/index.py
@@ -8,6 +8,7 @@ TARGET_PATTERN = re.compile(r"^\(([a-zA-Z0-9\|\@\<\>\*\.\/\_\-\+\:]{1,100})\)\=\
 
 
 def myst_block_plugin(md: MarkdownIt):
+    """Parse MyST targets (``(name)=``), blockquotes (``% comment``) and block breaks (``+++``)."""
     md.block.ruler.before(
         "blockquote",
         "myst_line_comment",

--- a/mdit_py_plugins/myst_role/index.py
+++ b/mdit_py_plugins/myst_role/index.py
@@ -8,6 +8,7 @@ PATTERN = re.compile(r"^\{([a-zA-Z0-9\_\-\+\:]{1,36})\}(`+)(?!`)(.+?)(?<!`)\2(?!
 
 
 def myst_role_plugin(md: MarkdownIt):
+    """Parse ``{role-name}`content```"""
     md.inline.ruler.before("backticks", "myst_role", myst_role)
     md.add_render_rule("myst_role", render_myst_role)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,6 +47,9 @@ testing =
     pytest>=3.6,<4
     pytest-cov
     pytest-regressions
+rtd =
+    myst-parser==0.14.0a3
+    sphinx-book-theme~=0.1.0
 
 [mypy]
 show_error_codes = True

--- a/tox.ini
+++ b/tox.ini
@@ -12,3 +12,10 @@ usedevelop = true
 [testenv:py{36,37,38,39}]
 extras = testing
 commands = pytest {posargs}
+
+[testenv:docs-{update,clean}]
+extras = rtd
+whitelist_externals = rm
+commands =
+    clean: rm -rf docs/_build
+    sphinx-build -nW --keep-going -b {posargs:html} docs/ docs/_build/{posargs:html}


### PR DESCRIPTION
Adapted from markdown-it-py plugins.md,
which will be removed and reference this.