### PR TITLE
Update markdown-it-py to version 1.1

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ project_urls =
 [options]
 packages = find:
 install_requires =
-    markdown-it-py~=1.0
+    markdown-it-py~=1.1
 python_requires = ~=3.6
 include_package_data = True
 zip_safe = True


### PR DESCRIPTION
According to our testing in Fedora, plugins work well with the latest version of markdown-it-py.