### PR TITLE
updated markdown-it-py version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ project_urls =
 [options]
 packages = find:
 install_requires =
-    markdown-it-py = >= 1.0.0
+    markdown-it-py>=1.0.0,<2.0.0
 python_requires = ~=3.6
 include_package_data = True
 zip_safe = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ project_urls =
 [options]
 packages = find:
 install_requires =
-    markdown-it-py~=1.0
+    markdown-it-py~=1.0.0
 python_requires = ~=3.6
 include_package_data = True
 zip_safe = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ project_urls =
 [options]
 packages = find:
 install_requires =
-    markdown-it-py~=1.0.0
+    markdown-it-py = >= 1.0.0
 python_requires = ~=3.6
 include_package_data = True
 zip_safe = True


### PR DESCRIPTION
poetry runs into issues installing because "1.0" != "1.0.0" that the version actually is.