### PR TITLE
👌 IMPROVE: AMSmath defaut HTML tags

### DIFF
--- a/mdit_py_plugins/amsmath/__init__.py
+++ b/mdit_py_plugins/amsmath/__init__.py
@@ -115,7 +115,4 @@ def amsmath_block(state: StateBlock, startLine: int, endLine: int, silent: bool)
 
 def render_amsmath_block(self, tokens, idx, options, env):
     token = tokens[idx]
-    return (
-        '<div class="math amsmath">\n'
-        f"{escapeHtml(token.content)}\n</div>\n"
-    )
+    return f'<div class="math amsmath">\n{escapeHtml(token.content)}\n</div>\n'

--- a/mdit_py_plugins/amsmath/__init__.py
+++ b/mdit_py_plugins/amsmath/__init__.py
@@ -116,6 +116,6 @@ def amsmath_block(state: StateBlock, startLine: int, endLine: int, silent: bool)
 def render_amsmath_block(self, tokens, idx, options, env):
     token = tokens[idx]
     return (
-        '<section class="amsmath">\n<eqn>\n'
-        f"{escapeHtml(token.content)}\n</eqn>\n</section>\n"
+        '<div class="math amsmath">\n'
+        f"{escapeHtml(token.content)}\n</div>\n"
     )

--- a/tests/fixtures/amsmath.md
+++ b/tests/fixtures/amsmath.md
@@ -4,13 +4,11 @@ equation environment:
 a = 1
 \end{equation}
 .
-<section class="amsmath">
-<eqn>
+<div class="math amsmath">
 \begin{equation}
 a = 1
 \end{equation}
-</eqn>
-</section>
+</div>
 .
 
 equation* environment:
@@ -19,13 +17,11 @@ equation* environment:
 a = 1
 \end{equation*}
 .
-<section class="amsmath">
-<eqn>
+<div class="math amsmath">
 \begin{equation*}
 a = 1
 \end{equation*}
-</eqn>
-</section>
+</div>
 .
 
 multline environment:
@@ -34,13 +30,11 @@ multline environment:
 a = 1
 \end{multline}
 .
-<section class="amsmath">
-<eqn>
+<div class="math amsmath">
 \begin{multline}
 a = 1
 \end{multline}
-</eqn>
-</section>
+</div>
 .
 
 multline* environment:
@@ -49,13 +43,11 @@ multline* environment:
 a = 1
 \end{multline*}
 .
-<section class="amsmath">
-<eqn>
+<div class="math amsmath">
 \begin{multline*}
 a = 1
 \end{multline*}
-</eqn>
-</section>
+</div>
 .
 
 gather environment:
@@ -64,13 +56,11 @@ gather environment:
 a = 1
 \end{gather}
 .
-<section class="amsmath">
-<eqn>
+<div class="math amsmath">
 \begin{gather}
 a = 1
 \end{gather}
-</eqn>
-</section>
+</div>
 .
 
 gather* environment:
@@ -79,13 +69,11 @@ gather* environment:
 a = 1
 \end{gather*}
 .
-<section class="amsmath">
-<eqn>
+<div class="math amsmath">
 \begin{gather*}
 a = 1
 \end{gather*}
-</eqn>
-</section>
+</div>
 .
 
 align environment:
@@ -94,13 +82,11 @@ align environment:
 a = 1
 \end{align}
 .
-<section class="amsmath">
-<eqn>
+<div class="math amsmath">
 \begin{align}
 a = 1
 \end{align}
-</eqn>
-</section>
+</div>
 .
 
 align* environment:
@@ -109,13 +95,11 @@ align* environment:
 a = 1
 \end{align*}
 .
-<section class="amsmath">
-<eqn>
+<div class="math amsmath">
 \begin{align*}
 a = 1
 \end{align*}
-</eqn>
-</section>
+</div>
 .
 
 alignat environment:
@@ -124,13 +108,11 @@ alignat environment:
 a = 1
 \end{alignat}
 .
-<section class="amsmath">
-<eqn>
+<div class="math amsmath">
 \begin{alignat}
 a = 1
 \end{alignat}
-</eqn>
-</section>
+</div>
 .
 
 alignat* environment:
@@ -139,13 +121,11 @@ alignat* environment:
 a = 1
 \end{alignat*}
 .
-<section class="amsmath">
-<eqn>
+<div class="math amsmath">
 \begin{alignat*}
 a = 1
 \end{alignat*}
-</eqn>
-</section>
+</div>
 .
 
 flalign environment:
@@ -154,13 +134,11 @@ flalign environment:
 a = 1
 \end{flalign}
 .
-<section class="amsmath">
-<eqn>
+<div class="math amsmath">
 \begin{flalign}
 a = 1
 \end{flalign}
-</eqn>
-</section>
+</div>
 .
 
 flalign* environment:
@@ -169,13 +147,11 @@ flalign* environment:
 a = 1
 \end{flalign*}
 .
-<section class="amsmath">
-<eqn>
+<div class="math amsmath">
 \begin{flalign*}
 a = 1
 \end{flalign*}
-</eqn>
-</section>
+</div>
 .
 
 equation environment, with before/after paragraphs:
@@ -187,13 +163,11 @@ a = 1
 after
 .
 <p>before</p>
-<section class="amsmath">
-<eqn>
+<div class="math amsmath">
 \begin{equation}
 a = 1
 \end{equation}
-</eqn>
-</section>
+</div>
 <p>after</p>
 .
 
@@ -205,13 +179,45 @@ equation environment, in list:
 .
 <ul>
 <li>
-<section class="amsmath">
-<eqn>
+<div class="math amsmath">
 \begin{equation}
   a = 1
   \end{equation}
-</eqn>
-</section>
+</div>
 </li>
 </ul>
+.
+
+`alignat` environment and HTML escaping
+.
+\begin{alignat}{3}
+    & d   = \frac{1}{1 + 0.2316419x}  \quad && a_1  = 0.31938153   \quad && a_2 = -0.356563782 \\
+    & a_3 = 1.781477937               \quad && a_4  = -1.821255978 \quad && a_5 = 1.330274429
+\end{alignat}
+.
+<div class="math amsmath">
+\begin{alignat}{3}
+    &amp; d   = \frac{1}{1 + 0.2316419x}  \quad &amp;&amp; a_1  = 0.31938153   \quad &amp;&amp; a_2 = -0.356563782 \\
+    &amp; a_3 = 1.781477937               \quad &amp;&amp; a_4  = -1.821255978 \quad &amp;&amp; a_5 = 1.330274429
+\end{alignat}
+</div>
+.
+
+`alignat*` environment and HTML escaping
+.
+\begin{alignat*}{3}
+& m   \quad && \text{módulo}            \quad && m>0\\
+& a   \quad && \text{multiplicador}     \quad && 0<a<m\\
+& c   \quad && \text{constante aditiva} \quad && 0\leq c<m\\
+& x_0 \quad && \text{valor inicial}     \quad && 0\leq x_0 <m
+\end{alignat*}
+.
+<div class="math amsmath">
+\begin{alignat*}{3}
+&amp; m   \quad &amp;&amp; \text{módulo}            \quad &amp;&amp; m&gt;0\\
+&amp; a   \quad &amp;&amp; \text{multiplicador}     \quad &amp;&amp; 0&lt;a&lt;m\\
+&amp; c   \quad &amp;&amp; \text{constante aditiva} \quad &amp;&amp; 0\leq c&lt;m\\
+&amp; x_0 \quad &amp;&amp; \text{valor inicial}     \quad &amp;&amp; 0\leq x_0 &lt;m
+\end{alignat*}
+</div>
 .


### PR DESCRIPTION
Changed the default rendering to: `<div class="math amsmath">{content}</div>`.

Added some tests to cover more realistic AMS math scenarios.

See also:
https://github.com/executablebooks/markdown-it-amsmath/pull/4
https://github.com/executablebooks/markdown-it-amsmath/issues/1