### PR TITLE
🐛: Anchor ids in separate renders should not affect each other.

### DIFF
--- a/mdit_py_plugins/anchors/index.py
+++ b/mdit_py_plugins/anchors/index.py
@@ -65,9 +65,8 @@ def _make_anchors_func(
     permalinkBefore: bool,
     permalinkSpace: bool,
 ):
-    slugs: Set[str] = set()
-
     def _anchor_func(state: StateCore):
+        slugs: Set[str] = set()
         for (idx, token) in enumerate(state.tokens):
             if token.type != "heading_open":
                 continue
@@ -112,7 +111,7 @@ def _make_anchors_func(
                         ([Token("text", "", 0, content=" ")] if permalinkSpace else [])
                         + link_tokens
                     )
-        slugs.clear()
+
     return _anchor_func
 
 

--- a/mdit_py_plugins/anchors/index.py
+++ b/mdit_py_plugins/anchors/index.py
@@ -112,7 +112,7 @@ def _make_anchors_func(
                         ([Token("text", "", 0, content=" ")] if permalinkSpace else [])
                         + link_tokens
                     )
-
+        slugs.clear()
     return _anchor_func
 
 


### PR DESCRIPTION
The anchors plugin remembered used anchor ids per MarkdownIt object for entire lifetime of the object. This means if you use the same MarkdownIt object to render multiple documents then the generated anchor ids will be affected by the order of rendered documents.

This PR makes it clear the known ids after anchors are generated, so separate renders should not affect each other.

This seems like a safe fix to my eyes but I haven't examined these systems in-depth. It does past the single anchors test still.