### PR TITLE
🐛 FIX: Parsing when newline is between footnote ID and first paragraph

### DIFF
--- a/mdit_py_plugins/footnote/index.py
+++ b/mdit_py_plugins/footnote/index.py
@@ -80,7 +80,7 @@ def footnote_def(state: StateBlock, startLine: int, endLine: int, silent: bool):
     if pos == start + 2:  # no empty footnote labels
         return False
     pos += 1
-    if pos + 1 >= maximum or state.srcCharCode[pos] != 0x3A:  # /* : */
+    if pos >= maximum or state.srcCharCode[pos] != 0x3A:  # /* : */
         return False
     if silent:
         return True

--- a/tests/fixtures/footnote.md
+++ b/tests/fixtures/footnote.md
@@ -326,3 +326,21 @@ Some text
 </ol>
 </section>
 .
+
+
+Newline after footnote identifier
+.
+[^a]
+
+[^a]:
+b
+.
+<p><sup class="footnote-ref"><a href="#fn1" id="fnref1">[1]</a></sup></p>
+<p>b</p>
+<hr class="footnotes-sep">
+<section class="footnotes">
+<ol class="footnotes-list">
+<li id="fn1" class="footnote-item"> <a href="#fnref1" class="footnote-backref"><-</a></li>
+</ol>
+</section>
+.


### PR DESCRIPTION
Closes https://github.com/executablebooks/mdit-py-plugins/issues/48

This merely fixes a porting issue -- Javascript upstream already works like this.