### PR TITLE
🔧 MAINTAIN: Fix pre-commit configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,7 @@ repos:
     hooks:
     - id: black
 
-  - repo: https://gitlab.com/pycqa/flake8
+  - repo: https://github.com/pycqa/flake8
     rev: 3.9.2
     hooks:
     - id: flake8


### PR DESCRIPTION
flake8 has been removed from gitlab so the URL needs to be fixed in .pre-commit-config.yaml