### PR TITLE
⬆️ UPGRADE: drop python 3.7

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -53,6 +53,14 @@ jobs:
         file: ./coverage.xml
         fail_ci_if_error: true
 
+  allgood:
+    runs-on: ubuntu-latest
+    needs:
+    - pre-commit
+    - tests
+    steps:
+    - run: echo "Great success!"
+
   publish:
 
     name: Publish to PyPi

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['pypy-3.7', '3.7', '3.8', '3.9', '3.10']
+        python-version: ['pypy-3.8', '3.8', '3.9', '3.10', '3.11']
 
     steps:
     - uses: actions/checkout@v2

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,7 +1,7 @@
 version: 2
 
 python:
-  version: 3
+  version: "3.8"
   install:
   - method: pip
     path: .

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,7 +21,6 @@ intersphinx_mapping = {
 html_title = "mdit-py-plugins"
 html_theme = "sphinx_book_theme"
 html_theme_options = {
-    "single_page": True,
     "use_edit_page_button": True,
     "repository_url": "https://github.com/executablebooks/mdit-py-plugins",
     "repository_branch": "master",

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,7 +22,7 @@ md = MarkdownIt("gfm-like")
 ```
 
 ```{seealso}
-See [](markdown_it:using)
+See <inv:markdown_it#using>
 ```
 
 ## mdit-py-plugins package
@@ -124,7 +124,7 @@ html_string = md.render("some *Markdown*")
 
 ## Write your own
 
-Use the `mdit_py_plugins` as a guide to write your own, following the [markdown-it design principles](markdown_it:architecture).
+Use the `mdit_py_plugins` as a guide to write your own, following the [markdown-it design principles](inv:markdown_it#architecture).
 
 There are many other plugins which could easily be ported from the JS versions (and hopefully will):
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,17 +14,17 @@ classifiers = [
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Topic :: Text Processing :: Markup",
 ]
 keywords = ["markdown", "markdown-it", "lexer", "parser", "development"]
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 dependencies = ["markdown-it-py>=1.0.0,<3.0.0"]
 
 [project.urls]
@@ -40,9 +40,8 @@ testing = [
     "pytest-regressions",
 ]
 rtd = [
-    "attrs",
-    "myst-parser~=0.16.1",
-    "sphinx-book-theme~=0.1.0",
+    "myst-parser",
+    "sphinx-book-theme",
 ]
 
 [tool.flit.module]

--- a/tox.ini
+++ b/tox.ini
@@ -4,12 +4,12 @@
 # then run `tox` or `tox -- {pytest args}`
 # run in parallel using `tox -p`
 [tox]
-envlist = py37
+envlist = py38
 
 [testenv]
 usedevelop = true
 
-[testenv:py{37,38,39,310}]
+[testenv:py{37,38,39,310,311}]
 extras = testing
 commands = pytest {posargs}
 


### PR DESCRIPTION
Python 3.7 is end-of-life on 2023-06-27 https://devguide.python.org/versions/

and add test for python 3.11