### PR TITLE
👌 Centralise code block test

### DIFF
--- a/mdit_py_plugins/admon/index.py
+++ b/mdit_py_plugins/admon/index.py
@@ -5,6 +5,8 @@ from typing import Callable, List, Optional, Tuple
 from markdown_it import MarkdownIt
 from markdown_it.rules_block import StateBlock
 
+from mdit_py_plugins.utils import is_code_block
+
 
 def _get_tag(params: str) -> Tuple[str, str]:
     """Separate the tag name from the admonition title."""
@@ -44,6 +46,9 @@ def _extra_classes(markup: str) -> List[str]:
 
 
 def admonition(state: StateBlock, startLine: int, endLine: int, silent: bool) -> bool:
+    if is_code_block(state, startLine):
+        return False
+
     start = state.bMarks[startLine] + state.tShift[startLine]
     maximum = state.eMarks[startLine]
 

--- a/mdit_py_plugins/amsmath/__init__.py
+++ b/mdit_py_plugins/amsmath/__init__.py
@@ -6,6 +6,8 @@ from markdown_it import MarkdownIt
 from markdown_it.common.utils import escapeHtml
 from markdown_it.rules_block import StateBlock
 
+from mdit_py_plugins.utils import is_code_block
+
 # Taken from amsmath version 2.1
 # http://anorien.csc.warwick.ac.uk/mirrors/CTAN/macros/latex/required/amsmath/amsldoc.pdf
 ENVIRONMENTS = [
@@ -92,8 +94,7 @@ def match_environment(string):
 
 
 def amsmath_block(state: StateBlock, startLine: int, endLine: int, silent: bool):
-    # if it's indented more than 3 spaces, it should be a code block
-    if state.sCount[startLine] - state.blkIndent >= 4:
+    if is_code_block(state, startLine):
         return False
 
     begin = state.bMarks[startLine] + state.tShift[startLine]

--- a/mdit_py_plugins/attrs/index.py
+++ b/mdit_py_plugins/attrs/index.py
@@ -7,6 +7,8 @@ from markdown_it.rules_core import StateCore
 from markdown_it.rules_inline import StateInline
 from markdown_it.token import Token
 
+from mdit_py_plugins.utils import is_code_block
+
 from .parse import ParseError, parse
 
 
@@ -156,8 +158,7 @@ def _attr_block_rule(
     The block must be a single line that begins with a `{`, after three or less spaces,
     and end with a `}` followed by any number if spaces.
     """
-    # if it's indented more than 3 spaces, it should be a code block
-    if state.sCount[startLine] - state.blkIndent >= 4:
+    if is_code_block(state, startLine):
         return False
 
     pos = state.bMarks[startLine] + state.tShift[startLine]

--- a/mdit_py_plugins/colon_fence.py
+++ b/mdit_py_plugins/colon_fence.py
@@ -2,6 +2,8 @@ from markdown_it import MarkdownIt
 from markdown_it.common.utils import escapeHtml, unescapeAll
 from markdown_it.rules_block import StateBlock
 
+from mdit_py_plugins.utils import is_code_block
+
 
 def colon_fence_plugin(md: MarkdownIt):
     """This plugin directly mimics regular fences, but with `:` colons.
@@ -24,13 +26,12 @@ def colon_fence_plugin(md: MarkdownIt):
 
 
 def _rule(state: StateBlock, startLine: int, endLine: int, silent: bool):
+    if is_code_block(state, startLine):
+        return False
+
     haveEndMarker = False
     pos = state.bMarks[startLine] + state.tShift[startLine]
     maximum = state.eMarks[startLine]
-
-    # if it's indented more than 3 spaces, it should be a code block
-    if state.sCount[startLine] - state.blkIndent >= 4:
-        return False
 
     if pos + 3 > maximum:
         return False
@@ -79,8 +80,7 @@ def _rule(state: StateBlock, startLine: int, endLine: int, silent: bool):
         if state.srcCharCode[pos] != marker:
             continue
 
-        if state.sCount[nextLine] - state.blkIndent >= 4:
-            # closing fence should be indented less than 4 spaces
+        if is_code_block(state, nextLine):
             continue
 
         pos = state.skipChars(pos, marker)

--- a/mdit_py_plugins/container/index.py
+++ b/mdit_py_plugins/container/index.py
@@ -6,6 +6,8 @@ from markdown_it import MarkdownIt
 from markdown_it.common.utils import charCodeAt
 from markdown_it.rules_block import StateBlock
 
+from mdit_py_plugins.utils import is_code_block
+
 
 def container_plugin(
     md: MarkdownIt,
@@ -52,6 +54,9 @@ def container_plugin(
     render = render or renderDefault
 
     def container_func(state: StateBlock, startLine: int, endLine: int, silent: bool):
+        if is_code_block(state, startLine):
+            return False
+
         auto_closed = False
         start = state.bMarks[startLine] + state.tShift[startLine]
         maximum = state.eMarks[startLine]
@@ -109,8 +114,7 @@ def container_plugin(
             if marker_char != state.srcCharCode[start]:
                 continue
 
-            if state.sCount[nextLine] - state.blkIndent >= 4:
-                # closing fence should be indented less than 4 spaces
+            if is_code_block(state, nextLine):
                 continue
 
             pos = start + 1

--- a/mdit_py_plugins/deflist/index.py
+++ b/mdit_py_plugins/deflist/index.py
@@ -2,6 +2,8 @@
 from markdown_it import MarkdownIt
 from markdown_it.rules_block import StateBlock
 
+from mdit_py_plugins.utils import is_code_block
+
 
 def deflist_plugin(md: MarkdownIt):
     """Plugin ported from
@@ -66,6 +68,9 @@ def deflist_plugin(md: MarkdownIt):
             i += 1
 
     def deflist(state: StateBlock, startLine: int, endLine: int, silent: bool):
+        if is_code_block(state, startLine):
+            return False
+
         if silent:
             # quirk: validation mode validates a dd block only, not a whole deflist
             if state.ddIndent < 0:

--- a/mdit_py_plugins/dollarmath/index.py
+++ b/mdit_py_plugins/dollarmath/index.py
@@ -6,6 +6,8 @@ from markdown_it.common.utils import escapeHtml, isWhiteSpace
 from markdown_it.rules_block import StateBlock
 from markdown_it.rules_inline import StateInline
 
+from mdit_py_plugins.utils import is_code_block
+
 
 def dollarmath_plugin(
     md: MarkdownIt,
@@ -262,13 +264,12 @@ def math_block_dollar(
     ) -> bool:
         # TODO internal backslash escaping
 
+        if is_code_block(state, startLine):
+            return False
+
         haveEndMarker = False
         startPos = state.bMarks[startLine] + state.tShift[startLine]
         end = state.eMarks[startLine]
-
-        # if it's indented more than 3 spaces, it should be a code block
-        if state.sCount[startLine] - state.blkIndent >= 4:
-            return False
 
         if startPos + 2 > end:
             return False

--- a/mdit_py_plugins/field_list/__init__.py
+++ b/mdit_py_plugins/field_list/__init__.py
@@ -5,6 +5,8 @@ from typing import Optional, Tuple
 from markdown_it import MarkdownIt
 from markdown_it.rules_block import StateBlock
 
+from mdit_py_plugins.utils import is_code_block
+
 
 def fieldlist_plugin(md: MarkdownIt):
     """Field lists are mappings from field names to field bodies, based on the
@@ -96,8 +98,7 @@ def set_parent_type(state: StateBlock, name: str):
 def _fieldlist_rule(state: StateBlock, startLine: int, endLine: int, silent: bool):
     # adapted from markdown_it/rules_block/list.py::list_block
 
-    # if it's indented more than 3 spaces, it should be a code block
-    if state.sCount[startLine] - state.blkIndent >= 4:
+    if is_code_block(state, startLine):
         return False
 
     posAfterName, name_text = parseNameMarker(state, startLine)
@@ -221,8 +222,7 @@ def _fieldlist_rule(state: StateBlock, startLine: int, endLine: int, silent: boo
             if state.sCount[nextLine] < state.blkIndent:
                 break
 
-            # if it's indented more than 3 spaces, it should be a code block
-            if state.sCount[startLine] - state.blkIndent >= 4:
+            if is_code_block(state, startLine):
                 break
 
             # get next field item

--- a/mdit_py_plugins/footnote/index.py
+++ b/mdit_py_plugins/footnote/index.py
@@ -10,6 +10,8 @@ from markdown_it.rules_block import StateBlock
 from markdown_it.rules_inline import StateInline
 from markdown_it.token import Token
 
+from mdit_py_plugins.utils import is_code_block
+
 
 def footnote_plugin(md: MarkdownIt):
     """Plugin ported from
@@ -56,6 +58,9 @@ def footnote_plugin(md: MarkdownIt):
 
 def footnote_def(state: StateBlock, startLine: int, endLine: int, silent: bool):
     """Process footnote block definition"""
+
+    if is_code_block(state, startLine):
+        return False
 
     start = state.bMarks[startLine] + state.tShift[startLine]
     maximum = state.eMarks[startLine]

--- a/mdit_py_plugins/front_matter/index.py
+++ b/mdit_py_plugins/front_matter/index.py
@@ -5,6 +5,8 @@ from markdown_it import MarkdownIt
 from markdown_it.common.utils import charCodeAt
 from markdown_it.rules_block import StateBlock
 
+from mdit_py_plugins.utils import is_code_block
+
 
 def front_matter_plugin(md: MarkdownIt):
     """Plugin ported from
@@ -88,8 +90,7 @@ def make_front_matter_rule():
             if marker_char != state.srcCharCode[start]:
                 continue
 
-            if state.sCount[nextLine] - state.blkIndent >= 4:
-                # closing fence should be indented less than 4 spaces
+            if is_code_block(state, nextLine):
                 continue
 
             pos = start + 1

--- a/mdit_py_plugins/myst_blocks/index.py
+++ b/mdit_py_plugins/myst_blocks/index.py
@@ -4,6 +4,8 @@ from markdown_it import MarkdownIt
 from markdown_it.common.utils import escapeHtml, isSpace
 from markdown_it.rules_block import StateBlock
 
+from mdit_py_plugins.utils import is_code_block
+
 
 def myst_block_plugin(md: MarkdownIt):
     """Parse MyST targets (``(name)=``), blockquotes (``% comment``) and block breaks (``+++``)."""
@@ -30,12 +32,11 @@ def myst_block_plugin(md: MarkdownIt):
 
 
 def line_comment(state: StateBlock, startLine: int, endLine: int, silent: bool):
+    if is_code_block(state, startLine):
+        return False
+
     pos = state.bMarks[startLine] + state.tShift[startLine]
     maximum = state.eMarks[startLine]
-
-    # if it's indented more than 3 spaces, it should be a code block
-    if state.sCount[startLine] - state.blkIndent >= 4:
-        return False
 
     if state.src[pos] != "%":
         return False
@@ -66,12 +67,11 @@ def line_comment(state: StateBlock, startLine: int, endLine: int, silent: bool):
 
 
 def block_break(state: StateBlock, startLine: int, endLine: int, silent: bool):
+    if is_code_block(state, startLine):
+        return False
+
     pos = state.bMarks[startLine] + state.tShift[startLine]
     maximum = state.eMarks[startLine]
-
-    # if it's indented more than 3 spaces, it should be a code block
-    if state.sCount[startLine] - state.blkIndent >= 4:
-        return False
 
     marker = state.srcCharCode[pos]
     pos += 1
@@ -109,12 +109,11 @@ def block_break(state: StateBlock, startLine: int, endLine: int, silent: bool):
 
 
 def target(state: StateBlock, startLine: int, endLine: int, silent: bool):
+    if is_code_block(state, startLine):
+        return False
+
     pos = state.bMarks[startLine] + state.tShift[startLine]
     maximum = state.eMarks[startLine]
-
-    # if it's indented more than 3 spaces, it should be a code block
-    if state.sCount[startLine] - state.blkIndent >= 4:
-        return False
 
     text = state.src[pos:maximum].strip()
     if not text.startswith("("):

--- a/mdit_py_plugins/substitution.py
+++ b/mdit_py_plugins/substitution.py
@@ -2,6 +2,8 @@ from markdown_it import MarkdownIt
 from markdown_it.rules_block import StateBlock
 from markdown_it.rules_inline import StateInline
 
+from mdit_py_plugins.utils import is_code_block
+
 
 def substitution_plugin(
     md: MarkdownIt, start_delimiter: str = "{", end_delimiter: str = "}"
@@ -67,12 +69,11 @@ def substitution_plugin(
     def _substitution_block(
         state: StateBlock, startLine: int, endLine: int, silent: bool
     ):
+        if is_code_block(state, startLine):
+            return False
+
         startPos = state.bMarks[startLine] + state.tShift[startLine]
         end = state.eMarks[startLine]
-
-        # if it's indented more than 3 spaces, it should be a code block
-        if state.sCount[startLine] - state.blkIndent >= 4:
-            return False
 
         lineText = state.src[startPos:end].strip()
 

--- a/mdit_py_plugins/utils.py
+++ b/mdit_py_plugins/utils.py
@@ -1,0 +1,12 @@
+from markdown_it.rules_block import StateBlock
+
+
+def is_code_block(state: StateBlock, line: int) -> bool:
+    """Check if the line is part of a code block, compat for markdown-it-py v2."""
+    try:
+        # markdown-it-py v3+
+        return state.is_code_block(line)  # type: ignore[attr-defined]
+    except AttributeError:
+        pass
+
+    return (state.sCount[line] - state.blkIndent) >= 4


### PR DESCRIPTION
All block level rules first test whether the first character is indented enough to be a code block. This logic is centralised, and allows for the `StateBlock.is_code_block` method, coming in markdown-it-py v3.0.0