### PR TITLE
🔧 Convert `state.srcCharCode` -> `state.src`

### DIFF
--- a/mdit_py_plugins/attrs/index.py
+++ b/mdit_py_plugins/attrs/index.py
@@ -1,7 +1,6 @@
 from typing import List, Optional
 
 from markdown_it import MarkdownIt
-from markdown_it.common.utils import isSpace
 from markdown_it.rules_block import StateBlock
 from markdown_it.rules_core import StateCore
 from markdown_it.rules_inline import StateInline
@@ -113,7 +112,7 @@ def _find_opening(tokens: List[Token], index: int) -> Optional[int]:
 
 
 def _span_rule(state: StateInline, silent: bool):
-    if state.srcCharCode[state.pos] != 0x5B:  # /* [ */
+    if state.src[state.pos] != "[":
         return False
 
     maximum = state.posMax
@@ -165,16 +164,16 @@ def _attr_block_rule(
     maximum = state.eMarks[startLine]
 
     # if it doesn't start with a {, it's not an attribute block
-    if state.srcCharCode[pos] != 0x7B:  # /* { */
+    if state.src[pos] != "{":
         return False
 
     # find first non-space character from the right
-    while maximum > pos and isSpace(state.srcCharCode[maximum - 1]):
+    while maximum > pos and state.src[maximum - 1] in (" ", "\t"):
         maximum -= 1
     # if it doesn't end with a }, it's not an attribute block
     if maximum <= pos:
         return False
-    if state.srcCharCode[maximum - 1] != 0x7D:  # /* } */
+    if state.src[maximum - 1] != "}":
         return False
 
     try:

--- a/mdit_py_plugins/colon_fence.py
+++ b/mdit_py_plugins/colon_fence.py
@@ -36,15 +36,14 @@ def _rule(state: StateBlock, startLine: int, endLine: int, silent: bool):
     if pos + 3 > maximum:
         return False
 
-    marker = state.srcCharCode[pos]
+    marker = state.src[pos]
 
-    # /* : */
-    if marker != 0x3A:
+    if marker != ":":
         return False
 
     # scan marker length
     mem = pos
-    pos = state.skipChars(pos, marker)
+    pos = _skipCharsStr(state, pos, marker)
 
     length = pos - mem
 
@@ -77,13 +76,13 @@ def _rule(state: StateBlock, startLine: int, endLine: int, silent: bool):
             #  test
             break
 
-        if state.srcCharCode[pos] != marker:
+        if state.src[pos] != marker:
             continue
 
         if is_code_block(state, nextLine):
             continue
 
-        pos = state.skipChars(pos, marker)
+        pos = _skipCharsStr(state, pos, marker)
 
         # closing code fence must be at least as long as the opening one
         if pos - mem < length:
@@ -111,6 +110,20 @@ def _rule(state: StateBlock, startLine: int, endLine: int, silent: bool):
     token.map = [startLine, state.line]
 
     return True
+
+
+def _skipCharsStr(state: StateBlock, pos: int, ch: str) -> int:
+    """Skip character string from given position."""
+    # TODO this can be replaced with StateBlock.skipCharsStr in markdown-it-py 3.0.0
+    while True:
+        try:
+            current = state.src[pos]
+        except IndexError:
+            break
+        if current != ch:
+            break
+        pos += 1
+    return pos
 
 
 def _render(self, tokens, idx, options, env):

--- a/mdit_py_plugins/container/index.py
+++ b/mdit_py_plugins/container/index.py
@@ -3,7 +3,6 @@ from math import floor
 from typing import Callable, Optional
 
 from markdown_it import MarkdownIt
-from markdown_it.common.utils import charCodeAt
 from markdown_it.rules_block import StateBlock
 
 from mdit_py_plugins.utils import is_code_block
@@ -48,7 +47,7 @@ def container_plugin(
 
     min_markers = 3
     marker_str = marker
-    marker_char = charCodeAt(marker_str, 0)
+    marker_char = marker_str[0]
     marker_len = len(marker_str)
     validate = validate or validateDefault
     render = render or renderDefault
@@ -63,7 +62,7 @@ def container_plugin(
 
         # Check out the first character quickly,
         # this should filter out most of non-containers
-        if marker_char != state.srcCharCode[start]:
+        if marker_char != state.src[start]:
             return False
 
         # Check out the rest of the marker string
@@ -111,7 +110,7 @@ def container_plugin(
                 #  test
                 break
 
-            if marker_char != state.srcCharCode[start]:
+            if marker_char != state.src[start]:
                 continue
 
             if is_code_block(state, nextLine):

--- a/mdit_py_plugins/deflist/index.py
+++ b/mdit_py_plugins/deflist/index.py
@@ -24,7 +24,6 @@ def deflist_plugin(md: MarkdownIt):
         ~ Definition 2b
 
     """
-    isSpace = md.utils.isSpace
 
     def skipMarker(state: StateBlock, line: int):
         """Search `[:~][\n ]`, returns next pos after marker on success or -1 on fail."""
@@ -35,9 +34,9 @@ def deflist_plugin(md: MarkdownIt):
             return -1
 
         # Check bullet
-        marker = state.srcCharCode[start]
+        marker = state.src[start]
         start += 1
-        if marker != 0x7E and marker != 0x3A:  # ~ :
+        if marker != "~" and marker != ":":
             return -1
 
         pos = state.skipSpaces(start)
@@ -139,13 +138,10 @@ def deflist_plugin(md: MarkdownIt):
                 )
 
                 while pos < maximum:
-                    ch = state.srcCharCode[pos]
-
-                    if isSpace(ch):
-                        if ch == 0x09:
-                            offset += 4 - offset % 4
-                        else:
-                            offset += 1
+                    if state.src[pos] == "\t":
+                        offset += 4 - offset % 4
+                    elif state.src[pos] == " ":
+                        offset += 1
                     else:
                         break
 

--- a/mdit_py_plugins/dollarmath/index.py
+++ b/mdit_py_plugins/dollarmath/index.py
@@ -105,7 +105,7 @@ def is_escaped(state: StateInline, back_pos: int, mod: int = 0) -> bool:
     backslashes = 0
     while back_pos >= 0:
         back_pos = back_pos - 1
-        if state.srcCharCode[back_pos] == 0x5C:  # /* \ */
+        if state.src[back_pos] == "\\":
             backslashes += 1
         else:
             break
@@ -153,13 +153,13 @@ def math_inline_dollar(
         # TODO options:
         # even/odd backslash escaping
 
-        if state.srcCharCode[state.pos] != 0x24:  # /* $ */
+        if state.src[state.pos] != "$":
             return False
 
         if not allow_space:
             # whitespace not allowed straight after opening $
             try:
-                if isWhiteSpace(state.srcCharCode[state.pos + 1]):
+                if isWhiteSpace(ord(state.src[state.pos + 1])):
                     return False
             except IndexError:
                 return False
@@ -176,7 +176,7 @@ def math_inline_dollar(
             return False
 
         try:
-            is_double = allow_double and state.srcCharCode[state.pos + 1] == 0x24
+            is_double = allow_double and state.src[state.pos + 1] == "$"
         except IndexError:
             return False
 
@@ -185,7 +185,7 @@ def math_inline_dollar(
         found_closing = False
         while not found_closing:
             try:
-                end = state.srcCharCode.index(0x24, pos)
+                end = state.src.index("$", pos)
             except ValueError:
                 return False
 
@@ -194,7 +194,7 @@ def math_inline_dollar(
                 continue
 
             try:
-                if is_double and state.srcCharCode[end + 1] != 0x24:
+                if is_double and state.src[end + 1] != "$":
                     pos = end + 1
                     continue
             except IndexError:
@@ -211,7 +211,7 @@ def math_inline_dollar(
         if not allow_space:
             # whitespace not allowed straight before closing $
             try:
-                if isWhiteSpace(state.srcCharCode[end - 1]):
+                if isWhiteSpace(ord(state.src[end - 1])):
                     return False
             except IndexError:
                 return False
@@ -274,10 +274,7 @@ def math_block_dollar(
         if startPos + 2 > end:
             return False
 
-        if (
-            state.srcCharCode[startPos] != 0x24
-            or state.srcCharCode[startPos + 1] != 0x24
-        ):  # /* $ */
+        if state.src[startPos] != "$" or state.src[startPos + 1] != "$":
             return False
 
         # search for end of block

--- a/mdit_py_plugins/field_list/__init__.py
+++ b/mdit_py_plugins/field_list/__init__.py
@@ -139,13 +139,13 @@ def _fieldlist_rule(state: StateBlock, startLine: int, endLine: int, silent: boo
 
             # find indent to start of body on first line
             while pos < maximum:
-                ch = state.srcCharCode[pos]
+                ch = state.src[pos]
 
-                if ch == 0x09:  # \t
+                if ch == "\t":
                     first_line_body_indent += (
                         4 - (first_line_body_indent + state.bsCount[nextLine]) % 4
                     )
-                elif ch == 0x20:  # \s
+                elif ch == " ":
                     first_line_body_indent += 1
                 else:
                     break

--- a/mdit_py_plugins/footnote/index.py
+++ b/mdit_py_plugins/footnote/index.py
@@ -4,7 +4,6 @@
 from typing import List, Optional
 
 from markdown_it import MarkdownIt
-from markdown_it.common.utils import isSpace
 from markdown_it.helpers import parseLinkLabel
 from markdown_it.rules_block import StateBlock
 from markdown_it.rules_inline import StateInline
@@ -69,23 +68,23 @@ def footnote_def(state: StateBlock, startLine: int, endLine: int, silent: bool):
     if start + 4 > maximum:
         return False
 
-    if state.srcCharCode[start] != 0x5B:  # /* [ */
+    if state.src[start] != "[":
         return False
-    if state.srcCharCode[start + 1] != 0x5E:  # /* ^ */
+    if state.src[start + 1] != "^":
         return False
 
     pos = start + 2
     while pos < maximum:
-        if state.srcCharCode[pos] == 0x20:
+        if state.src[pos] == " ":
             return False
-        if state.srcCharCode[pos] == 0x5D:  # /* ] */
+        if state.src[pos] == "]":
             break
         pos += 1
 
     if pos == start + 2:  # no empty footnote labels
         return False
     pos += 1
-    if pos >= maximum or state.srcCharCode[pos] != 0x3A:  # /* : */
+    if pos >= maximum or state.src[pos] != ":":
         return False
     if silent:
         return True
@@ -113,13 +112,12 @@ def footnote_def(state: StateBlock, startLine: int, endLine: int, silent: bool):
     )
 
     while pos < maximum:
-        ch = state.srcCharCode[pos]
+        ch = state.src[pos]
 
-        if isSpace(ch):
-            if ch == 0x09:
-                offset += 4 - offset % 4
-            else:
-                offset += 1
+        if ch == "\t":
+            offset += 4 - offset % 4
+        elif ch == " ":
+            offset += 1
 
         else:
             break
@@ -162,9 +160,9 @@ def footnote_inline(state: StateInline, silent: bool):
 
     if start + 2 >= maximum:
         return False
-    if state.srcCharCode[start] != 0x5E:  # /* ^ */
+    if state.src[start] != "^":
         return False
-    if state.srcCharCode[start + 1] != 0x5B:  # /* [ */
+    if state.src[start + 1] != "[":
         return False
 
     labelStart = start + 2
@@ -208,18 +206,18 @@ def footnote_ref(state: StateInline, silent: bool):
 
     if "footnotes" not in state.env or "refs" not in state.env["footnotes"]:
         return False
-    if state.srcCharCode[start] != 0x5B:  # /* [ */
+    if state.src[start] != "[":
         return False
-    if state.srcCharCode[start + 1] != 0x5E:  # /* ^ */
+    if state.src[start + 1] != "^":
         return False
 
     pos = start + 2
     while pos < maximum:
-        if state.srcCharCode[pos] == 0x20:
+        if state.src[pos] == " ":
             return False
-        if state.srcCharCode[pos] == 0x0A:
+        if state.src[pos] == "\n":
             return False
-        if state.srcCharCode[pos] == 0x5D:  # /* ] */
+        if state.src[pos] == "]":
             break
         pos += 1
 

--- a/mdit_py_plugins/front_matter/index.py
+++ b/mdit_py_plugins/front_matter/index.py
@@ -2,7 +2,6 @@
 from math import floor
 
 from markdown_it import MarkdownIt
-from markdown_it.common.utils import charCodeAt
 from markdown_it.rules_block import StateBlock
 
 from mdit_py_plugins.utils import is_code_block
@@ -33,7 +32,7 @@ def front_matter_plugin(md: MarkdownIt):
 def make_front_matter_rule():
     min_markers = 3
     marker_str = "-"
-    marker_char = charCodeAt(marker_str, 0)
+    marker_char = marker_str[0]
     marker_len = len(marker_str)
 
     def frontMatter(state: StateBlock, startLine: int, endLine: int, silent: bool):
@@ -44,7 +43,7 @@ def make_front_matter_rule():
 
         # Check out the first character of the first line quickly,
         # this should filter out non-front matter
-        if startLine != 0 or marker_char != state.srcCharCode[0]:
+        if startLine != 0 or marker_char != state.src[0]:
             return False
 
         # Check out the rest of the marker string
@@ -87,7 +86,7 @@ def make_front_matter_rule():
                 #  test
                 break
 
-            if marker_char != state.srcCharCode[start]:
+            if marker_char != state.src[start]:
                 continue
 
             if is_code_block(state, nextLine):

--- a/mdit_py_plugins/myst_blocks/index.py
+++ b/mdit_py_plugins/myst_blocks/index.py
@@ -1,7 +1,7 @@
 import itertools
 
 from markdown_it import MarkdownIt
-from markdown_it.common.utils import escapeHtml, isSpace
+from markdown_it.common.utils import escapeHtml
 from markdown_it.rules_block import StateBlock
 
 from mdit_py_plugins.utils import is_code_block
@@ -73,19 +73,19 @@ def block_break(state: StateBlock, startLine: int, endLine: int, silent: bool):
     pos = state.bMarks[startLine] + state.tShift[startLine]
     maximum = state.eMarks[startLine]
 
-    marker = state.srcCharCode[pos]
+    marker = state.src[pos]
     pos += 1
 
-    # Check block marker /* + */
-    if marker != 0x2B:
+    # Check block marker
+    if marker != "+":
         return False
 
     # markers can be mixed with spaces, but there should be at least 3 of them
 
     cnt = 1
     while pos < maximum:
-        ch = state.srcCharCode[pos]
-        if ch != marker and not isSpace(ch):
+        ch = state.src[pos]
+        if ch != marker and ch not in ("\t", " "):
             break
         if ch == marker:
             cnt += 1
@@ -103,7 +103,7 @@ def block_break(state: StateBlock, startLine: int, endLine: int, silent: bool):
     token.attrSet("class", "myst-block")
     token.content = state.src[pos:maximum].strip()
     token.map = [startLine, state.line]
-    token.markup = chr(marker) * cnt
+    token.markup = marker * cnt
 
     return True
 

--- a/mdit_py_plugins/myst_role/index.py
+++ b/mdit_py_plugins/myst_role/index.py
@@ -22,7 +22,7 @@ def myst_role(state: StateInline, silent: bool):
 
     # check for starting backslash escape
     try:
-        if state.srcCharCode[state.pos - 1] == 0x5C:  # /* \ */
+        if state.src[state.pos - 1] == "\\":
             # escaped (this could be improved in the case of edge case '\\{')
             return False
     except IndexError:

--- a/mdit_py_plugins/substitution.py
+++ b/mdit_py_plugins/substitution.py
@@ -20,14 +20,11 @@ def substitution_plugin(
 
     """
 
-    start_char = ord(start_delimiter)
-    end_char = ord(end_delimiter)
-
     def _substitution_inline(state: StateInline, silent: bool):
         try:
             if (
-                state.srcCharCode[state.pos] != start_char
-                or state.srcCharCode[state.pos + 1] != start_char
+                state.src[state.pos] != start_delimiter
+                or state.src[state.pos + 1] != start_delimiter
             ):
                 return False
         except IndexError:
@@ -37,11 +34,11 @@ def substitution_plugin(
         found_closing = False
         while True:
             try:
-                end = state.srcCharCode.index(end_char, pos)
+                end = state.src.index(end_delimiter, pos)
             except ValueError:
                 return False
             try:
-                if state.srcCharCode[end + 1] == end_char:
+                if state.src[end + 1] == end_delimiter:
                     found_closing = True
                     break
             except IndexError:


### PR DESCRIPTION
`state.srcCharCode` is deprecated in markdown-it-py v3, and so here we pre-emptively replace all incidences to `state.src`, i.e. using the string instead of the unicode integer.