### PR TITLE
Fix compatiblity of admonition with Python-Markdown #93

### DIFF
--- a/tests/fixtures/admon.md
+++ b/tests/fixtures/admon.md
@@ -29,7 +29,7 @@ Could contain block elements too
 
 Shows custom title
 .
-!!! note Custom title
+!!! note "Custom title"
 
     Some text
 
@@ -249,7 +249,7 @@ zzz</p>
 
 Renders unknown admonition type 
 .
-!!! unknown title
+!!! unknown "title"
     content
 .
 <div class="admonition unknown">


### PR DESCRIPTION
Align behavior of admonition with Python-Markdown, including CSS classes. This implementation might be a breaking change however because unquoted tokens are now treated as CSS classes.