### PR TITLE
👌 Improve parsing of nested amsmath

### DIFF
--- a/tests/fixtures/amsmath.md
+++ b/tests/fixtures/amsmath.md
@@ -204,6 +204,10 @@ equation environment, in block quote:
 > -0.707 & -0.408 & -0.577 \\
 > -0.    & -0.816 &  0.577
 > \end{matrix}
+
+> \begin{equation}
+a = 1
+\end{equation}
 .
 <blockquote>
 <div class="math amsmath">
@@ -212,6 +216,13 @@ equation environment, in block quote:
 -0.707 &amp; -0.408 &amp; -0.577 \\
 -0.    &amp; -0.816 &amp;  0.577
 \end{matrix}
+</div>
+</blockquote>
+<blockquote>
+<div class="math amsmath">
+\begin{equation}
+a = 1
+\end{equation}
 </div>
 </blockquote>
 .

--- a/tests/fixtures/amsmath.md
+++ b/tests/fixtures/amsmath.md
@@ -11,6 +11,15 @@ a = 1
 </div>
 .
 
+equation environment on one line:
+.
+\begin{equation}a = 1\end{equation}
+.
+<div class="math amsmath">
+\begin{equation}a = 1\end{equation}
+</div>
+.
+
 equation* environment:
 .
 \begin{equation*}
@@ -181,11 +190,30 @@ equation environment, in list:
 <li>
 <div class="math amsmath">
 \begin{equation}
-  a = 1
-  \end{equation}
+a = 1
+\end{equation}
 </div>
 </li>
 </ul>
+.
+
+equation environment, in block quote:
+.
+> \begin{matrix}
+> -0.707 &  0.408 &  0.577 \\
+> -0.707 & -0.408 & -0.577 \\
+> -0.    & -0.816 &  0.577
+> \end{matrix}
+.
+<blockquote>
+<div class="math amsmath">
+\begin{matrix}
+-0.707 &amp;  0.408 &amp;  0.577 \\
+-0.707 &amp; -0.408 &amp; -0.577 \\
+-0.    &amp; -0.816 &amp;  0.577
+\end{matrix}
+</div>
+</blockquote>
 .
 
 `alignat` environment and HTML escaping
@@ -242,7 +270,7 @@ Indented by 4 spaces, DISABLE-CODEBLOCKS
 .
 <div class="math amsmath">
 \begin{equation}
-    a = 1
-    \end{equation}
+a = 1
+\end{equation}
 </div>
 .


### PR DESCRIPTION
the previous logic was problematic for amsmath blocks nested in other blocs (such as blockquotes)

the parsing code now principally follows the logic in `markdown_it/rules_block/fence.py`, except that:

1. it allows for a closing tag on the same line as the opening tag, and
2. it does not allow for an opening tag without closing tag (i.e. no auto-closing)

fixes #117 