### PR TITLE
✨ Add GFM autolink and composite GFM plugins

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -43,6 +43,18 @@ html_string = md.render("some *Markdown*")
 .. autofunction:: mdit_py_plugins.front_matter.front_matter_plugin
 ```
 
+## GFM (GitHub Flavored Markdown)
+
+```{eval-rst}
+.. autofunction:: mdit_py_plugins.gfm.gfm_plugin
+```
+
+## GFM Autolinks
+
+```{eval-rst}
+.. autofunction:: mdit_py_plugins.gfm_autolink.gfm_autolink_plugin
+```
+
 ## Footnotes
 
 ```{eval-rst}

--- a/mdit_py_plugins/gfm/__init__.py
+++ b/mdit_py_plugins/gfm/__init__.py
@@ -8,6 +8,7 @@ Enables a set of plugins that together approximate GitHub's Markdown rendering:
 - Task lists (built-in, markdown-it-py >= 4.1.0)
 - Alerts (built-in, markdown-it-py >= 4.1.0)
 - Footnotes (``[^label]`` references and definitions)
+
 Optional extras:
 
 - Dollar math (``$...$`` / ``$$...$$``)

--- a/mdit_py_plugins/gfm/__init__.py
+++ b/mdit_py_plugins/gfm/__init__.py
@@ -1,0 +1,101 @@
+"""Composite GFM (GitHub Flavored Markdown) plugin.
+
+Enables a set of plugins that together approximate GitHub's Markdown rendering:
+
+- Tables (built-in)
+- Strikethrough with single and double tildes (built-in)
+- Autolinks (gfm_autolink plugin)
+- Task lists (built-in, markdown-it-py >= 4.1.0)
+- Alerts (built-in, markdown-it-py >= 4.1.0)
+- Footnotes (``[^label]`` references and definitions)
+Optional extras:
+
+- Dollar math (``$...$`` / ``$$...$$``)
+- Front matter (YAML)
+
+.. note::
+   Tag filtering (disallowed raw HTML tags) is not yet implemented.
+
+.. seealso::
+   - `GitHub Flavored Markdown Spec <https://github.github.com/gfm/>`__
+   - `GitHub basic formatting syntax
+     <https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax>`__
+
+.. versionadded:: 0.5.0
+
+Requires markdown-it-py >= 4.1.0.
+"""
+
+from __future__ import annotations
+
+from functools import lru_cache
+
+from markdown_it import MarkdownIt
+from markdown_it import __version__ as _mdit_version
+
+from mdit_py_plugins.dollarmath import dollarmath_plugin
+from mdit_py_plugins.footnote import footnote_plugin
+from mdit_py_plugins.front_matter import front_matter_plugin
+from mdit_py_plugins.gfm_autolink import gfm_autolink_plugin
+
+__all__ = ("gfm_plugin",)
+
+_MIN_VERSION = (4, 1, 0)
+
+
+@lru_cache(maxsize=8)
+def _parse_version(v: str) -> tuple[int, ...]:
+    """Parse a version string like '4.1.0' into a tuple of ints."""
+    return tuple(int(x) for x in v.split(".")[:3])
+
+
+def gfm_plugin(
+    md: MarkdownIt,
+    *,
+    dollarmath: bool = False,
+    front_matter: bool = False,
+    tasklists_editable: bool = False,
+) -> None:
+    """Enable GFM-like rendering.
+
+    Starts from the current parser configuration and enables the GFM
+    components on top.
+
+    :param dollarmath: Enable dollar-delimited math (``$...$``, ``$$...$$``).
+    :param front_matter: Enable YAML front matter (``---``).
+    :param tasklists_editable: If True, rendered task list checkboxes are not
+        disabled (i.e. they are interactive).
+    """
+    if _parse_version(_mdit_version) < _MIN_VERSION:
+        raise RuntimeError(
+            f"gfm_plugin requires markdown-it-py >= {'.'.join(str(x) for x in _MIN_VERSION)} "
+            f"(installed: {_mdit_version})"
+        )
+
+    # Enable table and strikethrough rules (built into markdown-it-py)
+    md.enable("table")
+    md.enable("strikethrough")
+
+    # GFM options available in markdown-it-py >= 4.1.0
+    md.options["tasklists"] = True
+    md.options["tasklists_editable"] = tasklists_editable
+    md.options["alerts"] = True
+    md.options["strikethrough_single_tilde"] = True
+    # GFM autolinks
+    md.use(gfm_autolink_plugin)
+
+    # Footnotes (inline footnotes ^[...] are not part of GFM)
+    md.use(footnote_plugin, inline=False)
+
+    # Dollar math (inline $...$ and block $$...$$)
+    if dollarmath:
+        md.use(dollarmath_plugin, allow_blank_lines=False)
+
+    # TODO: Tag filter — replace leading `<` with `&lt;` for disallowed raw
+    # HTML tags: <title>, <textarea>, <style>, <xmp>, <iframe>, <noembed>,
+    # <noframes>, <script>, <plaintext>.
+    # See https://github.github.com/gfm/#disallowed-raw-html-extension-
+
+    # Optional plugins
+    if front_matter:
+        md.use(front_matter_plugin)

--- a/mdit_py_plugins/gfm_autolink/__init__.py
+++ b/mdit_py_plugins/gfm_autolink/__init__.py
@@ -1,0 +1,15 @@
+"""GFM autolink extension plugin for markdown-it-py.
+
+Implements the `GFM autolink extension
+<https://github.github.com/gfm/#autolinks-extension->`_,
+which recognises bare URLs (``http://``, ``https://``, ``www.``),
+protocol links (``mailto:``, ``xmpp:``),
+and bare email addresses without requiring angle brackets.
+
+Ported from the Rust crate
+`markdown_it_autolink <https://github.com/markdown-it-rust/markdown-it-plugins.rs>`_.
+"""
+
+from .index import gfm_autolink_plugin
+
+__all__ = ("gfm_autolink_plugin",)

--- a/mdit_py_plugins/gfm_autolink/_match.py
+++ b/mdit_py_plugins/gfm_autolink/_match.py
@@ -33,7 +33,7 @@ _SPACE_CHARS = frozenset(" \t\r\n\x00\x0b\x0c")
 
 
 def _isspace(ch: str) -> bool:
-    return ch in _SPACE_CHARS or ch == "\r" or ch == "\n"
+    return ch in _SPACE_CHARS
 
 
 _LINK_END_ASSORTMENT = frozenset("?!.,:*_~'\"[]")

--- a/mdit_py_plugins/gfm_autolink/_match.py
+++ b/mdit_py_plugins/gfm_autolink/_match.py
@@ -1,0 +1,250 @@
+"""URL / email matching helpers for the GFM autolink extension.
+
+Ported from the Rust ``gfm_autolinks`` crate.
+"""
+
+from __future__ import annotations
+
+import unicodedata
+
+# ---------------------------------------------------------------------------
+# Character classification helpers
+# ---------------------------------------------------------------------------
+
+_VALID_PREV_CHARS = frozenset(" \t\r\n*_~(")
+
+
+def check_prev(ch: str) -> bool:
+    """Return ``True`` if *ch* is a valid preceding character for an autolink."""
+    return ch in _VALID_PREV_CHARS
+
+
+def _is_valid_hostchar(ch: str) -> bool:
+    """Return ``True`` if *ch* is valid inside a domain label (not whitespace/punctuation)."""
+    if ch.isspace():
+        return False
+    cat = unicodedata.category(ch)
+    # Unicode punctuation categories: Pc, Pd, Pe, Pf, Pi, Po, Ps
+    return not cat.startswith("P")
+
+
+# Characters that terminate a URL (before autolink_delim trimming).
+_SPACE_CHARS = frozenset(" \t\r\n\x00\x0b\x0c")
+
+
+def _isspace(ch: str) -> bool:
+    return ch in _SPACE_CHARS or ch == "\r" or ch == "\n"
+
+
+_LINK_END_ASSORTMENT = frozenset("?!.,:*_~'\"[]")
+
+
+def _autolink_delim(data: str, link_end: int) -> int:
+    """Trim trailing punctuation from a URL according to GFM rules."""
+    # Truncate at first '<'
+    for i, ch in enumerate(data[:link_end]):
+        if ch == "<":
+            link_end = i
+            break
+
+    while link_end > 0:
+        cclose = data[link_end - 1]
+
+        copen = "(" if cclose == ")" else None
+
+        if cclose in _LINK_END_ASSORTMENT:
+            link_end -= 1
+        elif cclose == ";":
+            new_end = link_end - 2
+            while new_end > 0 and data[new_end].isalpha():
+                new_end -= 1
+            if new_end < link_end - 2 and data[new_end] == "&":
+                link_end = new_end
+            else:
+                link_end -= 1
+        elif copen is not None:
+            opening = data[:link_end].count(copen)
+            closing = data[:link_end].count(cclose)
+            if closing <= opening:
+                break
+            link_end -= 1
+        else:
+            break
+
+    return link_end
+
+
+# ---------------------------------------------------------------------------
+# Domain validation
+# ---------------------------------------------------------------------------
+
+
+def _check_domain(data: str, allow_short: bool) -> int | None:
+    """Validate a domain name and return the length consumed, or ``None``."""
+    if not data:
+        return None
+
+    np = 0
+    uscore1 = 0
+    uscore2 = 0
+
+    for i, ch in enumerate(data):
+        if ch == "_":
+            uscore2 += 1
+        elif ch == ".":
+            uscore1 = uscore2
+            uscore2 = 0
+            np += 1
+        elif not _is_valid_hostchar(ch) and ch != "-":
+            if uscore1 == 0 and uscore2 == 0 and (allow_short or np > 0):
+                return i
+            return None
+        # else: valid hostchar or '-'
+
+    if (uscore1 > 0 or uscore2 > 0) and np <= 10:
+        return None
+    if allow_short or np > 0:
+        return len(data)
+    return None
+
+
+# ---------------------------------------------------------------------------
+# www matching
+# ---------------------------------------------------------------------------
+
+_EMAIL_OK = frozenset(".+-_")
+
+
+def match_www(text: str) -> tuple[str, int] | None:
+    """Match a bare ``www.`` URL at the start of *text*.
+
+    Returns ``(url_with_scheme, char_count)`` or ``None``.
+    """
+    if not text.startswith("www."):
+        return None
+
+    link_end = _check_domain(text[4:], False)
+    if link_end is None:
+        return None
+    # link_end is offset from position 4
+    link_end += 4
+
+    # extend to the end of non-space characters
+    while link_end < len(text) and not _isspace(text[link_end]):
+        link_end += 1
+
+    link_end = _autolink_delim(text, link_end)
+
+    matched = text[:link_end]
+    url = "http://" + matched
+    return url, len(matched)
+
+
+# ---------------------------------------------------------------------------
+# http(s):// matching
+# ---------------------------------------------------------------------------
+
+
+def match_http(text: str) -> tuple[str, int] | None:
+    """Match an ``http://`` or ``https://`` URL at the start of *text*.
+
+    Returns ``(url, char_count)`` or ``None``.
+    """
+    if text.startswith("http://"):
+        prefix_len = 7
+    elif text.startswith("https://"):
+        prefix_len = 8
+    else:
+        return None
+
+    link_end = _check_domain(text[prefix_len:], True)
+    if link_end is None:
+        return None
+    link_end += prefix_len
+
+    while link_end < len(text) and not _isspace(text[link_end]):
+        link_end += 1
+
+    link_end = _autolink_delim(text, link_end)
+
+    url = text[:link_end]
+    return url, len(url)
+
+
+# ---------------------------------------------------------------------------
+# Email matching
+# ---------------------------------------------------------------------------
+
+
+def match_email(text: str) -> tuple[str, int] | None:
+    """Match an email address (optionally prefixed by ``mailto:``/``xmpp:``)."""
+    pos = 0
+    protocol: str | None = None
+    if text.startswith("mailto:"):
+        protocol = "mailto"
+        pos = 7
+    elif text.startswith("xmpp:"):
+        protocol = "xmpp"
+        pos = 5
+
+    return match_any_email(text, pos, protocol)
+
+
+def match_any_email(
+    text: str, pos: int, protocol: str | None
+) -> tuple[str, int] | None:
+    """Match an email address in *text* starting the local-part scan at *pos*.
+
+    *protocol* is ``"mailto"``, ``"xmpp"``, or ``None`` (bare address).
+    Returns ``(url, char_count)`` or ``None``.
+    """
+    size = len(text)
+
+    # scan local part (before @)
+    start_pos = pos
+    while pos < size:
+        ch = text[pos]
+        if ch.isascii() and (ch.isalnum() or ch in _EMAIL_OK):
+            pos += 1
+            continue
+        if ch == "@":
+            break
+        return None
+
+    if pos == start_pos:
+        return None
+
+    # scan domain (after @)
+    link_end = pos + 1
+    np = 0
+    num_slash = 0
+
+    while link_end < size:
+        ch = text[link_end]
+        if ch.isascii() and ch.isalnum():
+            pass
+        elif ch == "@":
+            if protocol != "xmpp":
+                return None
+        elif (
+            ch == "."
+            and link_end < size - 1
+            and text[link_end + 1].isascii()
+            and text[link_end + 1].isalnum()
+        ):
+            np += 1
+        elif ch == "/" and protocol == "xmpp" and num_slash == 0:
+            num_slash += 1
+        elif ch != "-" and ch != "_":
+            break
+        link_end += 1
+
+    if link_end < 2 or np == 0:
+        return None
+    last_ch = text[link_end - 1]
+    if not (last_ch.isascii() and last_ch.isalpha()) and last_ch != ".":
+        return None
+
+    url = "mailto:" + text[:link_end] if protocol is None else text[:link_end]
+
+    return url, link_end

--- a/mdit_py_plugins/gfm_autolink/index.py
+++ b/mdit_py_plugins/gfm_autolink/index.py
@@ -2,11 +2,37 @@
 
 Three inline scanners are registered:
 
-- **gfm_autolink_www** (char ``w``): bare ``www.`` URLs
+- **gfm_autolink_www** (char ``w``): bare ``www.`` URLs.
+  Uses ``add_terminator_char("w")`` so the text scanner interrupts at ``w``.
 - **gfm_autolink_protocol** (char ``:``): ``http://``, ``https://``,
   ``mailto:``, ``xmpp:`` URLs via back-scanning ``pending``.
 - **gfm_autolink_email** (char ``@``): bare email addresses via
   back-scanning ``pending``.
+
+Since ``:`` and ``@`` are already default terminator characters in
+markdown-it-py, the protocol and email rules are invoked at every occurrence
+of those characters. They use a *back-scanning* approach: looking backwards
+through ``state.pending`` for a protocol prefix or email local-part that was
+accumulated by the text rule. This means every ``:`` and ``@`` in the
+document incurs a (cheap) regex check or character scan of pending text.
+
+The trade-off vs. a **core-rule** (post-processing) approach — which would
+walk the final token stream, find autolink patterns in text tokens, and
+split them — is:
+
+- **Inline approach** (current): simpler, integrates naturally with
+  ``state.linkLevel`` to suppress matching inside links, but relies on the
+  prefix being present in ``state.pending`` (if a prior inline rule consumed
+  part of the prefix, matching would fail — unlikely in practice).
+- **Core-rule approach**: guaranteed to find all autolinks regardless of
+  inline rule ordering, but requires token-stream surgery (splitting text
+  tokens and inserting link tokens) and cannot easily interact with nesting
+  guards like ``linkLevel``.
+
+The ``w`` terminator is the only *new* terminator added. It causes the text
+rule to interrupt at every ``w``, which is a minor performance cost for
+documents heavy in that letter, but necessary since ``www.`` must be matched
+from the start of the URL.
 
 Specification: https://github.github.com/gfm/#autolinks-extension-
 

--- a/mdit_py_plugins/gfm_autolink/index.py
+++ b/mdit_py_plugins/gfm_autolink/index.py
@@ -1,0 +1,269 @@
+"""GFM autolink extension rules.
+
+Three inline scanners are registered:
+
+- **gfm_autolink_www** (char ``w``): bare ``www.`` URLs
+- **gfm_autolink_protocol** (char ``:``): ``http://``, ``https://``,
+  ``mailto:``, ``xmpp:`` URLs via back-scanning ``pending``.
+- **gfm_autolink_email** (char ``@``): bare email addresses via
+  back-scanning ``pending``.
+
+Specification: https://github.github.com/gfm/#autolinks-extension-
+
+.. versionadded:: 0.5.0
+
+Requires markdown-it-py ≥ 4.1.0.
+"""
+
+from __future__ import annotations
+
+import re
+
+from markdown_it import MarkdownIt
+from markdown_it.rules_inline import StateInline
+
+from ._match import check_prev, match_any_email, match_http, match_www
+
+# Regex to back-scan pending text for a protocol name ending at the current
+# position (the colon character).
+_PROTO_RE = re.compile(r"(?:^|.)(https?|mailto|xmpp)$", re.DOTALL)
+
+
+def gfm_autolink_plugin(md: MarkdownIt) -> None:
+    """Enable the GFM autolink extension.
+
+    Recognises bare ``www.`` URLs, ``http(s)://`` URLs,
+    ``mailto:``/``xmpp:`` links, and bare email addresses.
+
+    Requires markdown-it-py ≥ 4.1.0.
+    """
+    if not hasattr(md.inline, "add_terminator_char"):
+        raise RuntimeError("gfm_autolink_plugin requires markdown-it-py >= 4.1.0")
+
+    md.inline.add_terminator_char("w")
+    md.inline.ruler.push("gfm_autolink_www", _www_inline_rule)
+    md.inline.ruler.push("gfm_autolink_protocol", _protocol_rule)
+    md.inline.ruler.push("gfm_autolink_email", _email_rule)
+
+
+# ---------------------------------------------------------------------------
+# Helpers (inline rules)
+# ---------------------------------------------------------------------------
+
+
+def _preceding_ok(state: StateInline, bscan_len: int) -> bool:
+    """Check whether the character before the back-scanned portion allows an autolink."""
+    abs_pos = state.pos - bscan_len
+    if abs_pos <= 0:
+        return True
+    preceding = state.src[abs_pos - 1]
+    return check_prev(preceding)
+
+
+def _create_autolink(
+    state: StateInline,
+    bscan_len: int,
+    total_len: int,
+    url: str,
+    text: str,
+) -> bool:
+    """Emit ``link_open`` / ``text`` / ``link_close`` tokens.
+
+    *bscan_len* characters are trimmed from the end of ``state.pending``
+    (the back-scanned protocol or local part).  The parser position is
+    then advanced by ``total_len - bscan_len`` characters.
+    """
+    if bscan_len:
+        state.pending = state.pending[:-bscan_len]
+
+    full_url = state.md.normalizeLink(url)
+    if not state.md.validateLink(full_url):
+        return False
+
+    token = state.push("link_open", "a", 1)
+    token.attrs = {"href": full_url}
+    token.markup = "autolink"
+    token.info = "auto"
+
+    token = state.push("text", "", 0)
+    token.content = state.md.normalizeLinkText(text)
+
+    token = state.push("link_close", "a", -1)
+    token.markup = "autolink"
+    token.info = "auto"
+
+    state.pos += total_len - bscan_len
+    return True
+
+
+# ---------------------------------------------------------------------------
+# www inline rule  (requires add_terminator_char("w") — markdown-it-py >= 4.1.0)
+# ---------------------------------------------------------------------------
+
+
+def _www_inline_rule(state: StateInline, silent: bool) -> bool:
+    """Match ``www.`` autolinks as an inline rule (trigger char: ``w``)."""
+    if state.linkLevel > 0:
+        return False
+
+    pos = state.pos
+    src = state.src
+
+    # Quick check: must be 'w' and form "www."
+    if src[pos] != "w":
+        return False
+    if pos + 4 > state.posMax or src[pos : pos + 4] != "www.":
+        return False
+
+    # Check preceding character (from pending text or start-of-line).
+    if state.pending:
+        preceding = state.pending[-1]
+        if not check_prev(preceding):
+            return False
+    elif pos > 0:
+        preceding = src[pos - 1]
+        if not check_prev(preceding):
+            return False
+
+    result = match_www(src[pos : state.posMax])
+    if result is None:
+        return False
+
+    url, length = result
+    label = src[pos : pos + length]
+
+    if silent:
+        return True
+
+    full_url = state.md.normalizeLink(url)
+    if not state.md.validateLink(full_url):
+        return False
+
+    token = state.push("link_open", "a", 1)
+    token.attrs = {"href": full_url}
+    token.markup = "autolink"
+    token.info = "auto"
+
+    token = state.push("text", "", 0)
+    token.content = state.md.normalizeLinkText(label)
+
+    token = state.push("link_close", "a", -1)
+    token.markup = "autolink"
+    token.info = "auto"
+
+    state.pos += length
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Protocol scanner  (trigger char: ':')
+# ---------------------------------------------------------------------------
+
+
+def _protocol_rule(state: StateInline, silent: bool) -> bool:
+    if state.linkLevel > 0:
+        return False
+
+    pos = state.pos
+    remaining = state.src[pos : state.posMax]
+
+    # Must start with ':' and have at least 3 more characters.
+    if len(remaining) < 4 or remaining[0] != ":":
+        return False
+
+    # Back-scan pending text for a known protocol name.
+    m = _PROTO_RE.search(state.pending)
+    if m is None:
+        return False
+
+    proto = m.group(1)
+    bscan_len = len(proto)
+
+    if not _preceding_ok(state, bscan_len):
+        return False
+
+    # Combine back-scanned protocol with the remaining text.
+    combined = proto + remaining
+
+    if proto in ("mailto", "xmpp"):
+        result = match_any_email(combined, bscan_len + 1, proto)
+    else:
+        result = match_http(combined)
+
+    if result is None:
+        return False
+
+    full_url, total_len = result
+    label = combined[:total_len]
+
+    if silent:
+        return True
+    return _create_autolink(state, bscan_len, total_len, full_url, label)
+
+
+# ---------------------------------------------------------------------------
+# Bare email scanner  (trigger char: '@')
+# ---------------------------------------------------------------------------
+
+
+def _email_rule(state: StateInline, silent: bool) -> bool:
+    if state.linkLevel > 0:
+        return False
+
+    pos = state.pos
+    if pos >= state.posMax or state.src[pos] != "@":
+        return False
+    # Need at least one character after '@'.
+    if pos + 1 >= state.posMax:
+        return False
+
+    # Back-scan pending text for the local part of the email.
+    local_rev: list[str] = []
+    for ch in reversed(state.pending):
+        if ch.isascii() and (ch.isalnum() or ch in ".+-_"):
+            local_rev.append(ch)
+        else:
+            break
+
+    if not local_rev:
+        return False
+
+    local_len = len(local_rev)
+    if not _preceding_ok(state, local_len):
+        return False
+
+    # Forward-scan for the domain part.
+    after_at = state.src[pos + 1 : state.posMax]
+    domain_len = 0
+    num_period = 0
+    for i, ch in enumerate(after_at):
+        if ch.isascii() and ch.isalnum():
+            pass
+        elif ch == "@":
+            return False
+        elif (
+            ch == "."
+            and i + 1 < len(after_at)
+            and after_at[i + 1].isascii()
+            and after_at[i + 1].isalnum()
+        ):
+            num_period += 1
+        elif ch != "-" and ch != "_":
+            break
+        domain_len += 1
+
+    if domain_len == 0 or num_period == 0:
+        return False
+
+    last_ch = after_at[domain_len - 1]
+    if not (last_ch.isascii() and last_ch.isalnum()) and last_ch != ".":
+        return False
+
+    local_part = "".join(reversed(local_rev))
+    email_text = local_part + state.src[pos : pos + 1 + domain_len]
+    total_len = local_len + 1 + domain_len
+    url = "mailto:" + email_text
+
+    if silent:
+        return True
+    return _create_autolink(state, local_len, total_len, url, email_text)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ testing = [
     "pytest",
     "pytest-cov",
     "pytest-regressions",
+    "pytest-timeout",
 ]
 rtd = [
     "myst-parser",
@@ -84,3 +85,6 @@ show_error_codes = true
 warn_unused_ignores = true
 warn_redundant_casts = true
 strict = true
+
+[tool.pytest.ini_options]
+timeout = 10

--- a/tests/fixtures/gfm.md
+++ b/tests/fixtures/gfm.md
@@ -1,0 +1,129 @@
+GFM: table
+.
+| foo | bar |
+| --- | --- |
+| baz | bim |
+.
+<table>
+<thead>
+<tr>
+<th>foo</th>
+<th>bar</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>baz</td>
+<td>bim</td>
+</tr>
+</tbody>
+</table>
+.
+
+GFM: strikethrough (double tilde)
+.
+~~hello~~
+.
+<p><s>hello</s></p>
+.
+
+GFM: strikethrough (single tilde)
+.
+~hello~
+.
+<p><s>hello</s></p>
+.
+
+GFM: autolink www
+.
+www.example.com
+.
+<p><a href="http://www.example.com">www.example.com</a></p>
+.
+
+GFM: autolink protocol
+.
+https://example.com
+.
+<p><a href="https://example.com">https://example.com</a></p>
+.
+
+GFM: autolink email
+.
+user@example.com
+.
+<p><a href="mailto:user@example.com">user@example.com</a></p>
+.
+
+GFM: task list
+.
+- [x] done
+- [ ] todo
+.
+<ul class="contains-task-list">
+<li class="task-list-item"><input class="task-list-item-checkbox" disabled="" type="checkbox" checked=""> done</li>
+<li class="task-list-item"><input class="task-list-item-checkbox" disabled="" type="checkbox"> todo</li>
+</ul>
+.
+
+GFM: alert
+.
+> [!NOTE]
+> This is a note.
+.
+<div class="markdown-alert markdown-alert-note">
+<p class="markdown-alert-title">Note</p>
+<p>This is a note.</p>
+</div>
+.
+
+GFM: combined features
+.
+Check out https://example.com for more info.
+
+~~old~~ and ~also old~
+
+- [x] visited www.example.com
+- [ ] email user@example.com
+.
+<p>Check out <a href="https://example.com">https://example.com</a> for more info.</p>
+<p><s>old</s> and <s>also old</s></p>
+<ul class="contains-task-list">
+<li class="task-list-item"><input class="task-list-item-checkbox" disabled="" type="checkbox" checked=""> visited <a href="http://www.example.com">www.example.com</a></li>
+<li class="task-list-item"><input class="task-list-item-checkbox" disabled="" type="checkbox"> email <a href="mailto:user@example.com">user@example.com</a></li>
+</ul>
+.
+
+GFM: footnotes
+.
+Here is a footnote[^1].
+
+[^1]: Footnote content.
+.
+<p>Here is a footnote<sup class="footnote-ref"><a href="#fn1" id="fnref1">[1]</a></sup>.</p>
+<hr class="footnotes-sep">
+<section class="footnotes">
+<ol class="footnotes-list">
+<li id="fn1" class="footnote-item"><p>Footnote content. <a href="#fnref1" class="footnote-backref">↩︎</a></p>
+</li>
+</ol>
+</section>
+.
+
+GFM: dollar math inline
+.
+Euler's formula: $e^{i\pi} + 1 = 0$
+.
+<p>Euler's formula: <span class="math inline">e^{i\pi} + 1 = 0</span></p>
+.
+
+GFM: dollar math block
+.
+$$
+x = \frac{-b \pm \sqrt{b^2 - 4ac}}{2a}
+$$
+.
+<div class="math block">
+x = \frac{-b \pm \sqrt{b^2 - 4ac}}{2a}
+</div>
+.

--- a/tests/fixtures/gfm_autolink.md
+++ b/tests/fixtures/gfm_autolink.md
@@ -1,0 +1,225 @@
+GFM autolink: www basic (spec 622)
+.
+www.commonmark.org
+.
+<p><a href="http://www.commonmark.org">www.commonmark.org</a></p>
+.
+
+GFM autolink: www with path (spec 623)
+.
+Visit www.commonmark.org/help for more information.
+.
+<p>Visit <a href="http://www.commonmark.org/help">www.commonmark.org/help</a> for more information.</p>
+.
+
+GFM autolink: trailing punctuation (spec 624)
+.
+Visit www.commonmark.org.
+
+Visit www.commonmark.org/a.b.
+.
+<p>Visit <a href="http://www.commonmark.org">www.commonmark.org</a>.</p>
+<p>Visit <a href="http://www.commonmark.org/a.b">www.commonmark.org/a.b</a>.</p>
+.
+
+GFM autolink: parentheses balancing (spec 625)
+.
+www.google.com/search?q=Markup+(business)
+
+www.google.com/search?q=Markup+(business)))
+
+(www.google.com/search?q=Markup+(business))
+
+(www.google.com/search?q=Markup+(business)
+.
+<p><a href="http://www.google.com/search?q=Markup+(business)">www.google.com/search?q=Markup+(business)</a></p>
+<p><a href="http://www.google.com/search?q=Markup+(business)">www.google.com/search?q=Markup+(business)</a>))</p>
+<p>(<a href="http://www.google.com/search?q=Markup+(business)">www.google.com/search?q=Markup+(business)</a>)</p>
+<p>(<a href="http://www.google.com/search?q=Markup+(business)">www.google.com/search?q=Markup+(business)</a></p>
+.
+
+GFM autolink: interior parens only (spec 626)
+.
+www.google.com/search?q=(business))+ok
+.
+<p><a href="http://www.google.com/search?q=(business))+ok">www.google.com/search?q=(business))+ok</a></p>
+.
+
+GFM autolink: entity reference exclusion (spec 627)
+.
+www.google.com/search?q=commonmark&hl=en
+
+www.google.com/search?q=commonmark&hl;
+.
+<p><a href="http://www.google.com/search?q=commonmark&amp;hl=en">www.google.com/search?q=commonmark&amp;hl=en</a></p>
+<p><a href="http://www.google.com/search?q=commonmark">www.google.com/search?q=commonmark</a>&amp;hl;</p>
+.
+
+GFM autolink: less-than ends autolink (spec 628)
+.
+www.commonmark.org/he<lp
+.
+<p><a href="http://www.commonmark.org/he">www.commonmark.org/he</a>&lt;lp</p>
+.
+
+GFM autolink: http/https (spec 629)
+.
+http://commonmark.org
+
+(Visit https://encrypted.google.com/search?q=Markup+(business))
+.
+<p><a href="http://commonmark.org">http://commonmark.org</a></p>
+<p>(Visit <a href="https://encrypted.google.com/search?q=Markup+(business)">https://encrypted.google.com/search?q=Markup+(business)</a>)</p>
+.
+
+GFM autolink: bare email (spec 630)
+.
+foo@bar.baz
+.
+<p><a href="mailto:foo@bar.baz">foo@bar.baz</a></p>
+.
+
+GFM autolink: email local part (spec 632 modified)
+.
+a.b-c-d@a.b
+
+a.b-c-d@a.b.
+
+a.b-c-d@a.b-
+
+a.b-c-d@a.b_
+.
+<p><a href="mailto:a.b-c-d@a.b">a.b-c-d@a.b</a></p>
+<p><a href="mailto:a.b-c-d@a.b">a.b-c-d@a.b</a>.</p>
+<p>a.b-c-d@a.b-</p>
+<p>a.b-c-d@a.b_</p>
+.
+
+GFM autolink: mailto/xmpp protocol (spec 633)
+.
+mailto:foo@bar.baz
+
+mailto:a.b-c_d@a.b
+
+mailto:a.b-c_d@a.b.
+
+mailto:a.b-c_d@a.b/
+
+mailto:a.b-c_d@a.b-
+
+mailto:a.b-c_d@a.b_
+
+xmpp:foo@bar.baz
+
+xmpp:foo@bar.baz.
+.
+<p><a href="mailto:foo@bar.baz">mailto:foo@bar.baz</a></p>
+<p><a href="mailto:a.b-c_d@a.b">mailto:a.b-c_d@a.b</a></p>
+<p><a href="mailto:a.b-c_d@a.b">mailto:a.b-c_d@a.b</a>.</p>
+<p><a href="mailto:a.b-c_d@a.b">mailto:a.b-c_d@a.b</a>/</p>
+<p>mailto:a.b-c_d@a.b-</p>
+<p>mailto:a.b-c_d@a.b_</p>
+<p><a href="xmpp:foo@bar.baz">xmpp:foo@bar.baz</a></p>
+<p><a href="xmpp:foo@bar.baz">xmpp:foo@bar.baz</a>.</p>
+.
+
+GFM autolink: xmpp resource (spec 634)
+.
+xmpp:foo@bar.baz/txt
+
+xmpp:foo@bar.baz/txt@bin
+
+xmpp:foo@bar.baz/txt@bin.com
+.
+<p><a href="xmpp:foo@bar.baz/txt">xmpp:foo@bar.baz/txt</a></p>
+<p><a href="xmpp:foo@bar.baz/txt@bin">xmpp:foo@bar.baz/txt@bin</a></p>
+<p><a href="xmpp:foo@bar.baz/txt@bin.com">xmpp:foo@bar.baz/txt@bin.com</a></p>
+.
+
+GFM autolink: trailing delimiters
+.
+http://google.com/he<lp
+mailto:bob@google.co<m
+bob@google.co<m
+
+http://google.com/(business)
+http://google.com/(business))
+
+http://google.com/other_
+.
+<p><a href="http://google.com/he">http://google.com/he</a>&lt;lp
+<a href="mailto:bob@google.co">mailto:bob@google.co</a>&lt;m
+<a href="mailto:bob@google.co">bob@google.co</a>&lt;m</p>
+<p><a href="http://google.com/(business)">http://google.com/(business)</a>
+<a href="http://google.com/(business)">http://google.com/(business)</a>)</p>
+<p><a href="http://google.com/other">http://google.com/other</a>_</p>
+.
+
+GFM autolink: integration with other syntax
+.
+**www.example.com**
+
+*https://example.com*
+.
+<p><strong><a href="http://www.example.com">www.example.com</a></strong></p>
+<p><em><a href="https://example.com">https://example.com</a></em></p>
+.
+
+GFM autolink: not inside links
+.
+[http://example.com](http://example.com)
+[mailto:bob@example.com](https://example.com)
+[bob@example.com](https://example.com)
+.
+<p><a href="http://example.com">http://example.com</a>
+<a href="https://example.com">mailto:bob@example.com</a>
+<a href="https://example.com">bob@example.com</a></p>
+.
+
+GFM autolink: preceded by letter (no match)
+.
+awww.example.com
+ahttps://example.com
+amailto:bob@example.com
+.
+<p>awww.example.com
+ahttps://example.com
+amailto:bob@example.com</p>
+.
+
+GFM autolink: email plus in local part
+.
+hello@mail+xyz.example
+
+hello+xyz@mail.example
+.
+<p>hello@mail+xyz.example</p>
+<p><a href="mailto:hello+xyz@mail.example">hello+xyz@mail.example</a></p>
+.
+
+GFM autolink: angle bracket autolink still works
+.
+<http://www.example.com>www.example.com
+.
+<p><a href="http://www.example.com">http://www.example.com</a>www.example.com</p>
+.
+
+GFM autolink: non-match cases
+.
+example.com
+
+www.
+
+@example.com
+.
+<p>example.com</p>
+<p>www.</p>
+<p>@example.com</p>
+.
+
+GFM autolink: xmpp no second slash
+.
+xmpp:foo@bar.baz/txt/bin
+.
+<p><a href="xmpp:foo@bar.baz/txt">xmpp:foo@bar.baz/txt</a>/bin</p>
+.

--- a/tests/test_gfm.py
+++ b/tests/test_gfm.py
@@ -1,0 +1,25 @@
+"""Tests for the composite GFM plugin."""
+
+from pathlib import Path
+
+from markdown_it import MarkdownIt
+from markdown_it.utils import read_fixture_file
+import pytest
+
+from mdit_py_plugins.gfm import gfm_plugin
+
+FIXTURE_PATH = Path(__file__).parent.joinpath("fixtures", "gfm.md")
+
+
+@pytest.mark.parametrize("line,title,input,expected", read_fixture_file(FIXTURE_PATH))
+def test_gfm_fixtures(line, title, input, expected):
+    md = MarkdownIt("commonmark").use(
+        gfm_plugin, dollarmath="dollar math" in title.lower()
+    )
+    md.options["xhtmlOut"] = False
+    text = md.render(input)
+    try:
+        assert text.rstrip() == expected.rstrip()
+    except AssertionError:
+        print(text)
+        raise

--- a/tests/test_gfm_autolink.py
+++ b/tests/test_gfm_autolink.py
@@ -1,0 +1,23 @@
+"""Tests for the GFM autolink extension plugin."""
+
+from pathlib import Path
+
+from markdown_it import MarkdownIt
+from markdown_it.utils import read_fixture_file
+import pytest
+
+from mdit_py_plugins.gfm_autolink import gfm_autolink_plugin
+
+FIXTURE_PATH = Path(__file__).parent.joinpath("fixtures", "gfm_autolink.md")
+
+
+@pytest.mark.parametrize("line,title,input,expected", read_fixture_file(FIXTURE_PATH))
+def test_gfm_autolink_fixtures(line, title, input, expected):
+    md = MarkdownIt("commonmark").use(gfm_autolink_plugin)
+    md.options.xhtmlOut = False
+    text = md.render(input)
+    try:
+        assert text.rstrip() == expected.rstrip()
+    except AssertionError:
+        print(text)
+        raise

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,7 @@ usedevelop = true
 
 [testenv:py{310,311,312,313}]
 extras = testing
+deps = markdown-it-py>=4.1.0
 commands = pytest {posargs}
 
 [testenv:docs-{update,clean}]


### PR DESCRIPTION
## Summary

Adds two new plugins that require markdown-it-py >= 4.1.0:

### `gfm_autolink` — GFM autolink literals

Implements the [GFM autolinks extension](https://github.github.com/gfm/#autolinks-extension-)
with three inline scanners:

- `www.` URLs (trigger char: `w`, via `add_terminator_char`)
- `http://`/`https://`/`mailto:`/`xmpp:` URLs (trigger char: `:`)
- Bare email addresses (trigger char: `@`)

Matching logic is ported from the Rust
[gfm_autolinks](https://github.com/markdown-it-rust/markdown-it-plugins.rs/tree/main/crates/gfm-autolinks)
crate. Covers GFM spec examples 622–635 plus additional edge cases
(trailing delimiters, emphasis integration, parentheses balancing, etc.).

### `gfm` — Composite GFM plugin

A single-call plugin that enables a GFM-like configuration:

- Tables (built-in)
- Strikethrough with single and double tildes (built-in)
- GFM autolinks (`gfm_autolink`)
- Task lists (built-in)
- Alerts (built-in)
- Footnotes (`footnote_plugin`, inline=False)
- Dollar math (optional, disabled by default)
- Front matter (optional, disabled by default)

Tag filtering is noted as a TODO.

### Other changes

- `tox.ini`: test envs pin `markdown-it-py>=4.1.0`
- `pyproject.toml`: added `pytest-timeout` to testing extras

### References

- [GFM spec](https://github.github.com/gfm/)
- [GitHub basic formatting syntax](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax)
- markdown-it-py 4.1.0 `add_terminator_char` API (PR executablebooks/markdown-it-py#391)