### PR TITLE
🔧 Switch PyPI publishing to trusted publishing (OIDC)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -65,23 +65,20 @@ jobs:
 
   publish:
 
-    name: Publish to PyPi
+    name: Publish to PyPI
     needs: [pre-commit, tests]
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    environment:
+      name: pypi
+      url: https://pypi.org/p/mdit-py-plugins
     steps:
-    - name: Checkout source
-      uses: actions/checkout@v4
-    - name: Set up Python
-      uses: actions/setup-python@v5
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: "3.10"
-    - name: install flit
-      run: |
-        pip install flit~=3.4
-    - name: Build and publish
-      run: |
-        flit publish
-      env:
-        FLIT_USERNAME: __token__
-        FLIT_PASSWORD: ${{ secrets.PYPI_KEY }}
+    - run: pip install flit~=3.4
+    - run: flit build
+    - uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Replace long-lived API token with PyPI trusted publishing via pypa/gh-action-pypi-publish. This uses short-lived OIDC credentials scoped to the CI workflow, eliminating the need for stored secrets.