### PR TITLE
✨ NEW: Add section reference plugin (section_ref)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- ✨ NEW: Add section reference plugin (`section_ref`)
+- ✨ NEW: Add section reference plugin (`section_ref`) (#144)
 
   The `section_ref` plugin captures section-sign references — the syntax LLMs
   commonly use to point at numbered headings — into dedicated `section_ref` tokens,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@
   ```
 
   A `§` must be immediately followed by ASCII digits (dot-separated for nested
-  levels, no spaces); the number string is stored on the token's `meta["number"]`.
+  levels, no spaces); the parsed section number is stored on the token's
+  `meta["numbers"]` as a list of ints (e.g. `[1, 1]` for `§1.1`).
 
   **Requires markdown-it-py >= 4.1.0.**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Change Log
 
+## Unreleased
+
+- ✨ NEW: Add section reference plugin (`section_ref`)
+
+  The `section_ref` plugin captures section-sign references — the syntax LLMs
+  commonly use to point at numbered headings — into dedicated `section_ref` tokens,
+  so downstream renderers (e.g. MyST-Parser) can resolve them to heading cross-references:
+
+  ```markdown
+  See §1, §1.1 and §2.3.4 for details.
+  ```
+
+  A `§` must be immediately followed by ASCII digits (dot-separated for nested
+  levels, no spaces); the number string is stored on the token's `meta["number"]`.
+
+  **Requires markdown-it-py >= 4.1.0.**
+
 ## 0.6.1 - 2026-05-13
 
 - 🐛 FIX: Nested field lists incorrectly nesting inside parent containers (#139)

--- a/docs/index.md
+++ b/docs/index.md
@@ -137,6 +137,12 @@ html_string = md.render("some *Markdown*")
 .. autofunction:: mdit_py_plugins.superscript.superscript_plugin
 ```
 
+## Section References
+
+```{eval-rst}
+.. autofunction:: mdit_py_plugins.section_ref.section_ref_plugin
+```
+
 ## MyST plugins
 
 `myst_blocks` and `myst_role` plugins are also available, for utilisation by the [MyST renderer](https://myst-parser.readthedocs.io/en/latest/using/syntax.html)

--- a/mdit_py_plugins/section_ref/__init__.py
+++ b/mdit_py_plugins/section_ref/__init__.py
@@ -1,0 +1,12 @@
+"""Section reference plugin for markdown-it-py.
+
+Captures section-sign references such as ``§1``, ``§1.1`` and ``§2.3.4``
+into dedicated ``section_ref`` tokens, so downstream renderers
+(e.g. MyST-Parser) can resolve them to numbered heading cross-references.
+
+Requires markdown-it-py >= 4.1.0.
+"""
+
+from .index import section_ref_plugin
+
+__all__ = ("section_ref_plugin",)

--- a/mdit_py_plugins/section_ref/index.py
+++ b/mdit_py_plugins/section_ref/index.py
@@ -1,0 +1,95 @@
+"""Section reference inline rule.
+
+A single inline scanner is registered on the character ``§``:
+
+- **section_ref** (char ``§``): section-sign references like ``§1.2``.
+
+``§`` is *not* one of markdown-it-py's default text-rule terminator
+characters, so the text rule would otherwise swallow it mid-paragraph and
+the inline rule would never fire.  ``add_terminator_char("§")`` makes the
+text rule interrupt at every ``§``, giving this rule a chance to run.  That
+API is only available in markdown-it-py >= 4.1.0.
+
+Requires markdown-it-py >= 4.1.0.
+"""
+
+from collections.abc import Sequence
+import re
+from typing import TYPE_CHECKING
+
+from markdown_it import MarkdownIt
+from markdown_it.common.utils import escapeHtml
+from markdown_it.rules_inline import StateInline
+
+if TYPE_CHECKING:
+    from markdown_it.renderer import RendererProtocol
+    from markdown_it.token import Token
+    from markdown_it.utils import EnvType, OptionsDict
+
+# ASCII digits only (``[0-9]``, never ``\d`` which also matches unicode digits).
+_SECTION_REF_PATTERN = re.compile(r"§([0-9]+(?:\.[0-9]+)*)")
+
+
+def section_ref_plugin(md: MarkdownIt) -> None:
+    """Parse section-sign references such as ``§1``, ``§1.1`` and ``§2.3.4``.
+
+    A reference is a ``§`` immediately followed by ASCII digits, optionally
+    grouped into further ``.``-separated levels (no spaces are allowed).
+    A trailing dot is not consumed, so ``see §1.`` captures ``§1``.  A ``§``
+    directly followed by an ASCII letter (e.g. ``§1a``) is *not* a reference,
+    but a following non-ASCII letter does not block a match, so ``见§3章``
+    still captures ``§3``.  Following CommonMark backslash-escape behaviour,
+    ``\\§1`` stays literal text, while ``\\\\§1`` renders a literal backslash
+    followed by a live reference.
+
+    Each reference becomes a ``section_ref`` token, with the matched text
+    (e.g. ``"§1.1"``) as its ``content``, ``markup`` set to ``§`` and
+    ``meta["number"]`` holding the number string (e.g. ``"1.1"``), so that
+    downstream renderers can resolve it to a heading target.
+
+    The default rendering is ``<span class="section-ref">§1.1</span>``.
+    Override it with ``md.add_render_rule("section_ref", ...)``.
+
+    .. versionadded:: 0.7.0
+
+    Requires markdown-it-py >= 4.1.0.
+    """
+    if not hasattr(md.inline, "add_terminator_char"):
+        raise RuntimeError("section_ref_plugin requires markdown-it-py >= 4.1.0")
+
+    md.inline.add_terminator_char("§")
+    md.inline.ruler.push("section_ref", _section_ref_rule)
+    md.add_render_rule("section_ref", render_section_ref)
+
+
+def _section_ref_rule(state: StateInline, silent: bool) -> bool:
+    match = _SECTION_REF_PATTERN.match(state.src, state.pos, state.posMax)
+    if not match:
+        return False
+
+    # reject when directly followed by an ASCII letter (e.g. "§1a", "§1.2b"),
+    # which indicates the text is not a plain section-number reference
+    # (a following non-ASCII letter such as CJK must not block the match)
+    end = match.end()
+    if end < state.posMax and state.src[end].isascii() and state.src[end].isalpha():
+        return False
+
+    if not silent:
+        token = state.push("section_ref", "", 0)
+        token.content = match.group(0)
+        token.markup = "§"
+        token.meta = {"number": match.group(1)}
+
+    state.pos = end
+    return True
+
+
+def render_section_ref(
+    self: "RendererProtocol",
+    tokens: Sequence["Token"],
+    idx: int,
+    options: "OptionsDict",
+    env: "EnvType",
+) -> str:
+    token = tokens[idx]
+    return f'<span class="section-ref">{escapeHtml(token.content)}</span>'

--- a/mdit_py_plugins/section_ref/index.py
+++ b/mdit_py_plugins/section_ref/index.py
@@ -44,8 +44,10 @@ def section_ref_plugin(md: MarkdownIt) -> None:
 
     Each reference becomes a ``section_ref`` token, with the matched text
     (e.g. ``"§1.1"``) as its ``content``, ``markup`` set to ``§`` and
-    ``meta["number"]`` holding the number string (e.g. ``"1.1"``), so that
-    downstream renderers can resolve it to a heading target.
+    ``meta["numbers"]`` holding the parsed section number as a list of ints
+    (e.g. ``[1, 1]`` for ``§1.1``), so that downstream renderers can resolve
+    it to a heading target without re-parsing.  Leading zeros are normalized
+    (``§01.02`` gives ``[1, 2]``); the original text remains in ``content``.
 
     The default rendering is ``<span class="section-ref">§1.1</span>``.
     Override it with ``md.add_render_rule("section_ref", ...)``.
@@ -78,7 +80,7 @@ def _section_ref_rule(state: StateInline, silent: bool) -> bool:
         token = state.push("section_ref", "", 0)
         token.content = match.group(0)
         token.markup = "§"
-        token.meta = {"number": match.group(1)}
+        token.meta = {"numbers": [int(part) for part in match.group(1).split(".")]}
 
     state.pos = end
     return True

--- a/tests/fixtures/section_ref.md
+++ b/tests/fixtures/section_ref.md
@@ -55,6 +55,13 @@ Trailing comma:
 <p><span class="section-ref">§3</span>, and more</p>
 .
 
+Trailing possessive apostrophe:
+.
+§4.3's rules
+.
+<p><span class="section-ref">§4.3</span>'s rules</p>
+.
+
 Inside emphasis:
 .
 *important: §2.1*

--- a/tests/fixtures/section_ref.md
+++ b/tests/fixtures/section_ref.md
@@ -135,7 +135,7 @@ Followed by non-digit, non-space char (not captured):
 <p>§x and §.5</p>
 .
 
-Leading zeros preserved:
+Leading zeros preserved in content (meta numbers are normalized):
 .
 §01.02
 .

--- a/tests/fixtures/section_ref.md
+++ b/tests/fixtures/section_ref.md
@@ -1,0 +1,157 @@
+
+Basic single-level:
+.
+See §1 for details.
+.
+<p>See <span class="section-ref">§1</span> for details.</p>
+.
+
+Nested number:
+.
+See §1.2.3 for details.
+.
+<p>See <span class="section-ref">§1.2.3</span> for details.</p>
+.
+
+At start and end of a paragraph:
+.
+§1 opens and closes §2
+.
+<p><span class="section-ref">§1</span> opens and closes <span class="section-ref">§2</span></p>
+.
+
+Multiple refs and a range:
+.
+Compare §1.1-§1.4 and also §2
+.
+<p>Compare <span class="section-ref">§1.1</span>-<span class="section-ref">§1.4</span> and also <span class="section-ref">§2</span></p>
+.
+
+Adjacent refs:
+.
+§1§2
+.
+<p><span class="section-ref">§1</span><span class="section-ref">§2</span></p>
+.
+
+Trailing period:
+.
+See §1.
+.
+<p>See <span class="section-ref">§1</span>.</p>
+.
+
+Parenthesised:
+.
+(§2)
+.
+<p>(<span class="section-ref">§2</span>)</p>
+.
+
+Trailing comma:
+.
+§3, and more
+.
+<p><span class="section-ref">§3</span>, and more</p>
+.
+
+Inside emphasis:
+.
+*important: §2.1*
+.
+<p><em>important: <span class="section-ref">§2.1</span></em></p>
+.
+
+Inside link text:
+.
+[see §1](https://example.com)
+.
+<p><a href="https://example.com">see <span class="section-ref">§1</span></a></p>
+.
+
+Inside inline code (not captured):
+.
+`§1`
+.
+<p><code>§1</code></p>
+.
+
+Inside fenced code block (not captured):
+.
+```
+§1
+```
+.
+<pre><code>§1
+</code></pre>
+.
+
+Bare section sign (not captured):
+.
+just a § here
+.
+<p>just a § here</p>
+.
+
+Space between sign and number (not captured):
+.
+§ 1
+.
+<p>§ 1</p>
+.
+
+Followed by ASCII letter, single level (not captured):
+.
+§1a
+.
+<p>§1a</p>
+.
+
+Followed by ASCII letter, nested (not captured):
+.
+§1.2b
+.
+<p>§1.2b</p>
+.
+
+Backslash-escaped (not captured):
+.
+\§1
+.
+<p>\§1</p>
+.
+
+Escaped backslash before ref (captured):
+.
+\\§1
+.
+<p>\<span class="section-ref">§1</span></p>
+.
+
+Followed by non-digit, non-space char (not captured):
+.
+§x and §.5
+.
+<p>§x and §.5</p>
+.
+
+Leading zeros preserved:
+.
+§01.02
+.
+<p><span class="section-ref">§01.02</span></p>
+.
+
+In a heading:
+.
+## About §2
+.
+<h2>About <span class="section-ref">§2</span></h2>
+.
+
+Non-ASCII letter after ref does not block match:
+.
+见§3章
+.
+<p>见<span class="section-ref">§3</span>章</p>
+.

--- a/tests/test_section_ref.py
+++ b/tests/test_section_ref.py
@@ -1,0 +1,128 @@
+from pathlib import Path
+from types import SimpleNamespace
+
+from markdown_it import MarkdownIt
+from markdown_it.token import Token
+from markdown_it.utils import read_fixture_file
+import pytest
+
+from mdit_py_plugins.section_ref import section_ref_plugin
+
+FIXTURE_PATH = Path(__file__).parent.joinpath("fixtures", "section_ref.md")
+
+
+def test_token():
+    md = MarkdownIt().use(section_ref_plugin)
+    src = "see §1.2 here"
+    tokens = md.parse(src)
+    print(tokens)
+    assert tokens == [
+        Token(
+            type="paragraph_open",
+            tag="p",
+            nesting=1,
+            attrs=None,
+            map=[0, 1],
+            level=0,
+            children=None,
+            content="",
+            markup="",
+            info="",
+            meta={},
+            block=True,
+            hidden=False,
+        ),
+        Token(
+            type="inline",
+            tag="",
+            nesting=0,
+            attrs=None,
+            map=[0, 1],
+            level=1,
+            children=[
+                Token(
+                    type="text",
+                    tag="",
+                    nesting=0,
+                    attrs=None,
+                    map=None,
+                    level=0,
+                    children=None,
+                    content="see ",
+                    markup="",
+                    info="",
+                    meta={},
+                    block=False,
+                    hidden=False,
+                ),
+                Token(
+                    type="section_ref",
+                    tag="",
+                    nesting=0,
+                    attrs=None,
+                    map=None,
+                    level=0,
+                    children=None,
+                    content="§1.2",
+                    markup="§",
+                    info="",
+                    meta={"number": "1.2"},
+                    block=False,
+                    hidden=False,
+                ),
+                Token(
+                    type="text",
+                    tag="",
+                    nesting=0,
+                    attrs=None,
+                    map=None,
+                    level=0,
+                    children=None,
+                    content=" here",
+                    markup="",
+                    info="",
+                    meta={},
+                    block=False,
+                    hidden=False,
+                ),
+            ],
+            content="see §1.2 here",
+            markup="",
+            info="",
+            meta={},
+            block=True,
+            hidden=False,
+        ),
+        Token(
+            type="paragraph_close",
+            tag="p",
+            nesting=-1,
+            attrs=None,
+            map=None,
+            level=0,
+            children=None,
+            content="",
+            markup="",
+            info="",
+            meta={},
+            block=True,
+            hidden=False,
+        ),
+    ]
+
+
+def test_runtime_error():
+    """The plugin requires the ``add_terminator_char`` API (markdown-it-py >= 4.1.0)."""
+    md = MarkdownIt()
+    md.inline = SimpleNamespace()  # type: ignore[assignment]  # lacks add_terminator_char
+    with pytest.raises(RuntimeError, match="requires markdown-it-py"):
+        section_ref_plugin(md)
+
+
+@pytest.mark.parametrize("line,title,input,expected", read_fixture_file(FIXTURE_PATH))
+def test_all(line, title, input, expected):
+    md = MarkdownIt("commonmark").use(section_ref_plugin)
+    md.options["xhtmlOut"] = False
+    text = md.render(input)
+    print(text)
+    assert text.rstrip() == expected.rstrip()

--- a/tests/test_section_ref.py
+++ b/tests/test_section_ref.py
@@ -66,7 +66,7 @@ def test_token():
                     content="§1.2",
                     markup="§",
                     info="",
-                    meta={"number": "1.2"},
+                    meta={"numbers": [1, 2]},
                     block=False,
                     hidden=False,
                 ),


### PR DESCRIPTION
## What

Adds a new `section_ref` inline plugin that captures section-sign references — `§1`, `§1.1`, `§2.3.4` — the syntax LLMs commonly use to refer to numbered headings in documents.

```markdown
See §1, §1.1 and §2.3.4 for details.
```

Each reference becomes a dedicated `section_ref` token:

- `content`: the matched text (e.g. `"§1.1"`)
- `markup`: `"§"`
- `meta["numbers"]`: the parsed section number as a list of ints (e.g. `[1, 1]`), so consumers don't re-parse the dotted string (a list rather than a tuple so `Token.as_dict()`/JSON round-trips are type-stable; leading zeros are normalized, with the original text preserved in `content`)

so downstream renderers (notably MyST-Parser) can resolve them to heading cross-references. The default rendering is a neutral `<span class="section-ref">§1.1</span>`, overridable via `md.add_render_rule("section_ref", ...)`.

## Initial use case

executablebooks/MyST-Parser#1170 (draft) consumes this plugin as a new `section_ref` MyST extension, resolving the references to internal links targeting the correspondingly numbered heading of the document. That PR is blocked on this one being merged and released (it needs `mdit-py-plugins >= 0.7`).

## Matching rules

- `§` must be *immediately* followed by ASCII digits (`[0-9]`, never unicode digits), optionally in further dot-separated groups — `§ 1` and bare `§` stay literal text
- trailing punctuation is not consumed: `see §1.` captures `§1`
- a directly-following ASCII letter rejects the match (`§1a`, `§1.2b`), while non-ASCII letters do not block it (`见§3章` captures `§3`)
- standard CommonMark backslash-escaping applies: `\§1` stays literal
- inline code, code fences, autolinked URLs, and link destinations/titles are unaffected

## Implementation notes

`§` is not one of markdown-it's default text-rule terminator characters, so a plain inline rule would never fire mid-paragraph. The plugin therefore uses `md.inline.add_terminator_char("§")`, the same mechanism as the `gfm_autolink` plugin, and raises a `RuntimeError` on markdown-it-py &lt; 4.1.0 (package dependency range unchanged).

## Testing

- 24 new tests: token-contract test, version-guard test, and 22 rendering fixtures (`tests/fixtures/section_ref.md`) covering emphasis/link/code/heading contexts, boundary and escaping edge cases
- full suite passes (507 tests); ruff + mypy `--strict` clean under both markdown-it-py 3.x and 4.x
- adversarially probed against a MyST-style plugin stack (`attrs`, `myst_role`, `dollarmath`, `gfm_autolink`, `footnote`, `deflist`, `anchors`), GFM autolink URLs containing `§`, link-label `posMax` slices, the typographer, and cross-instance state leakage

