### PR TITLE
🐛 FIX: myst_role backslash-guard misparse at inline start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@
 
   **Requires markdown-it-py >= 4.1.0.**
 
+- 🐛 FIX: `myst_role` no longer mis-rejects a role at the start of inline content when the content ends with a backslash, and `\\{name}`x`` (an escaped backslash before a role) now parses the role (#62)
+
 ## 0.6.1 - 2026-05-13
 
 - 🐛 FIX: Nested field lists incorrectly nesting inside parent containers (#139)

--- a/mdit_py_plugins/myst_role/index.py
+++ b/mdit_py_plugins/myst_role/index.py
@@ -21,19 +21,14 @@ def myst_role_plugin(md: MarkdownIt) -> None:
 
 
 def myst_role(state: StateInline, silent: bool) -> bool:
+    # note ``\{`` escaping is handled by the core ``escape`` rule,
+    # which runs before this rule
+
     # check name
     match = VALID_NAME_PATTERN.match(state.src[state.pos :])
     if not match:
         return False
     name = match.group(1)
-
-    # check for starting backslash escape
-    try:
-        if state.src[state.pos - 1] == "\\":
-            # escaped (this could be improved in the case of edge case '\\{')
-            return False
-    except IndexError:
-        pass
 
     # scan opening tick length
     start = pos = state.pos + match.end()

--- a/tests/fixtures/myst_role.md
+++ b/tests/fixtures/myst_role.md
@@ -102,3 +102,24 @@ Escaped:
 .
 <p>{abc}<code>xyz</code></p>
 .
+
+Role at start with trailing backslash (#62):
+.
+{foo}`ar`\
+.
+<p><code class="myst role">{foo}[ar]</code>\</p>
+.
+
+Escaped role backslash:
+.
+\{foo}`x`
+.
+<p>{foo}<code>x</code></p>
+.
+
+Escaped double backslash before role (#62):
+.
+\\{foo}`x`
+.
+<p>\<code class="myst role">{foo}[x]</code></p>
+.


### PR DESCRIPTION
## What

Fixes #62: `myst_role` misparsed inline content that **starts** with a role and **ends** with a backslash:

```python
md.render("{foo}`ar`\\")
# before: <p>{foo}<code>ar</code>\</p>          (role not captured)
# after:  <p><code class="myst role">{foo}[ar]</code>\</p>
```

## Why

The "starting backslash escape" guard read `state.src[state.pos - 1]`. At `state.pos == 0` that is Python negative indexing — it reads the **last** character of the inline source (the `except IndexError` never fires), so a role at the start of the inline was rejected whenever the content ended with `\`.

The guard is removed entirely rather than bounds-checked, because it was wrong in both remaining respects too:

- For its intended case (`\{foo}`x``) it was dead code: `{` is CommonMark-escapable, so the core `escape` rule (which runs before this rule) consumes `\{` wholesale — `myst_role` is never invoked there. Verified unchanged before/after.
- For an escaped backslash (`\\{foo}`x``) it wrongly suppressed a live role; it now renders a literal `\` followed by the parsed role, matching the CommonMark analogy (`\\*a*` → `\<em>a</em>`). This is the "edge case `\\{`" the guard's own comment flagged as broken.

This mirrors the analysis done for the `section_ref` plugin in #144, where the same guard pattern was dropped.

## Testing

- 3 new fixture cases: the #62 repro, `\{foo}`x`` (still escaped, via the core rule), and `\\{foo}`x`` (now a live role).
- Adversarially probed old-vs-new behavior across commonmark/default/gfm presets, table cells, link labels, image alts, and emphasis adjacency: the only differences are the two intended fixes. Full suite 511 passed; ruff and strict mypy clean.
- Sole caveat: in a `zero`-preset config *without* the core `escape` rule, `\{foo}`x`` now parses the role (previously suppressed-but-still-literal-backslash). No realistic consumer runs `myst_role` without the escape rule; a code comment now documents the assumption.

Note: the same latent `state.src[state.pos - 1]` wraparound exists in `dollarmath` (only reachable with the non-default `allow_digits=False`) — left for a separate PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LwRkZLzpbHdb3pgmctmn6H)_