### PR TITLE
fix: strip nested prefixes from multi-line dollarmath blocks

### DIFF
--- a/mdit_py_plugins/dollarmath/index.py
+++ b/mdit_py_plugins/dollarmath/index.py
@@ -287,6 +287,22 @@ def math_inline_dollar(
 DOLLAR_EQNO_REV = re.compile(r"^\s*\)([^)$\r\n]+?)\(\s*\${2}")
 
 
+def _math_block_content(
+    state: StateBlock, startLine: int, startPos: int, endLine: int, end: int
+) -> str:
+    """Extract math body, omitting parent container prefixes on each line."""
+    content_start = startPos + 2
+    if startLine == endLine:
+        return state.src[content_start:end]
+
+    parts: list[str] = [state.src[content_start : state.eMarks[startLine]], "\n"]
+    for line in range(startLine + 1, endLine):
+        parts.append(state.src[state.bMarks[line] : state.eMarks[line]])
+        parts.append("\n")
+    parts.append(state.src[state.bMarks[endLine] : end])
+    return "".join(parts)
+
+
 def math_block_dollar(
     allow_labels: bool = True,
     label_normalizer: Callable[[str], str] | None = None,
@@ -365,7 +381,7 @@ def math_block_dollar(
 
         token = state.push("math_block_label" if label else "math_block", "math", 0)
         token.block = True
-        token.content = state.src[startPos + 2 : end]
+        token.content = _math_block_content(state, startLine, startPos, nextLine, end)
         token.markup = "$$"
         token.map = [startLine, state.line]
         if label:

--- a/tests/fixtures/dollar_math.md
+++ b/tests/fixtures/dollar_math.md
@@ -418,6 +418,39 @@ a+b=c
 </blockquote>
 .
 
+display equation in blockquote, multi-line. (valid=True)
+.
+> Given
+>
+> $$
+> x^2 + y^2 = 9
+> $$
+>
+> What is the radius of the circle?
+.
+<blockquote>
+<p>Given</p>
+<div class="math block">
+x^2 + y^2 = 9
+</div>
+<p>What is the radius of the circle?</p>
+</blockquote>
+.
+
+labelled display equation in blockquote, multi-line. (valid=True)
+.
+> $$
+> a+b=c
+> $$ (2)
+.
+<blockquote>
+<div id="2" class="math block">
+<a href="#2" class="mathlabel" title="Permalink to this equation">¶</a>
+a+b=c
+</div>
+</blockquote>
+.
+
 mixed syntax:
 .
 $$


### PR DESCRIPTION
Multi-line `$$` math inside a blockquote was keeping the `>` prefix in the equation, which rendered as `&gt;`.

The block parser took a raw `src` slice from the opening `$$` to the closing one. Parent block rules rewrite `bMarks` so each line's content starts after the container prefix, but a contiguous slice still includes those prefixes on later lines. Content is now built per line from `bMarks`.

Fixes #125